### PR TITLE
CryoEngines methalox and NFLV engines

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/loc_atomic_cryo.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/loc_atomic_cryo.cfg
@@ -12,16 +12,28 @@ Localization
     #LOC_KerbalAtomics_ntr-gc-25-2_title =   LV-NGX 'Emancipator' Atomic Rocket Motor            // NV-GX
     #LOC_KerbalAtomics_ntr-sc-375-1_title =  LV-NGZ 'Scylla' Atomic Aerospike Rocket             // NV-DC
 
-	// CryoEngines
-    #LOC_CryoEngines_cryoengine-stromboli-1_title = CR-06 'Stromboli' Cryogenic Rocket Engine                // CR-10A                                                                 
+	  // CryoEngines
+    #LOC_CryoEngines_cryoengine-stromboli-1_title = CR-06 'Stromboli' Cryogenic Rocket Engine                // CR-10A
     #LOC_CryoEngines_cryoengine-vesuvius-1_title  = CR-12 'Vesuvius' Cryogenic Rocket Engine                   // CR-2
     #LOC_CryoEngines_cryoengine-hecate-1_title    = CE-12 'Hecate' Cryogenic Rocket Engine                    // CE-10
     #LOC_CryoEngines_cryoengine-erebus-1_title    = CR-18 'Erebus' Cryogenic Rocket Engine                  // CR-0120
     #LOC_CryoEngines_cryoengine-pavonis-1_title   = CE-18 'Pavonis' Cryogenic Rocket Engine                   // CE-60
     #LOC_CryoEngines_cryoengine-fuji-1_title      = CR-25 'Fuji' Cryogenic Rocket Engine                      // CR-9B
-    #LOC_CryoEngines_cryoengine-ulysses-1_title   = CE-25X 'Ulysses' Cryogenic Rocket Engine                   // CE-2X   // // leave X 
+    #LOC_CryoEngines_cryoengine-ulysses-1_title   = CE-25X 'Ulysses' Cryogenic Rocket Engine                   // CE-2X   // // leave X
     #LOC_CryoEngines_cryoengine-etna-1_title      = CR-37 'Etna' Cryogenic Rocket Engine                      // CR-68
     #LOC_CryoEngines_cryoengine-tharsis-1_title   = CE-37 'Tharsis' Cryogenic Rocket Engine Cluster           // CE-60
+
+    // CryoEngines Methalox
+    #LOC_CryoEngines_cryoengine-compsognathus-1_title = MR-06 'Compsognathus' Liquid Rocket Engine           // MR-1
+    #LOC_CryoEngines_cryoengine-hawk-1_title          = MU-06 'Hawk' Liquid Rocket Engine                    // MU-018
+    #LOC_CryoEngines_cryoengine-deinonychus-1_title   = MR-12 'Deinonychus' Liquid Rocket Engine             // MR-420
+    #LOC_CryoEngines_cryoengine-buzzard-1_title       = MU-12 'Buzzard' Liquid Rocket Engine                 // MU-10
+    #LOC_CryoEngines_cryoengine-iguanodon-1_title     = MR-18 'Iguanodon' Liquid Rocket Engine               // MR-4
+    #LOC_CryoEngines_cryoengine-harrier-1_title       = MU-18 'Harrier' Liquid Rocket Engine                 // MU-11
+    #LOC_CryoEngines_cryoengine-allosaur-1_title      = MR-25 'Allosaur' Liquid Rocket Engine                // MR-8
+    #LOC_CryoEngines_cryoengine-eagle-1_title         = MU-25 'Eagle' Liquid Rocket Engine                   // MU-421
+    #LOC_CryoEngines_cryoengine-tyrannosaur-1_title   = MR-37 'Tyrannosaur' Liquid Rocket Engine Cluster     // MR-420-9
+    #LOC_CryoEngines_cryoengine-vulture-1_title       = MU-37 'Vulture' Liquid Rocket Engine                 // MU-4U
 
     // CryoEngines old (pre-1.0)
     #LOC_CryoEngines_cryoengine-125-1_title = CE12 'Volcano' Cryogenic Rocket Engine       // KL-1
@@ -30,8 +42,6 @@ Localization
     #LOC_CryoEngines_cryoengine-25-2_title =  CE25X 'Tunguska' Cryogenic Rocket Engine     // CT2X
     #LOC_CryoEngines_cryoengine-375-1_title = CE37 'Mars' Cryogenic Rocket Engine          // KL-68
     #LOC_CryoEngines_cryoengine-375-2_title = CE37 'Yucatan' Cryogenic Rocket Engine       // CT65
-
-
 
     // CryoTanks
     #LOC_CryoTanks_hydrogen-radial-125-1_title = YDR-01 Hydrogen Tank  // HR-1

--- a/GameData/002_CommunityPartsTitles/Localization/loc_nf-spacecraft_nf-launch-vehicles.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/loc_nf-spacecraft_nf-launch-vehicles.cfg
@@ -89,74 +89,74 @@ Localization
 
     // 5m
     // ======
-    #LOC_NFLaunchVehicles_nflv-drone-5-1_title                = RC-50 Guidance Computer Unit (N-Series) // R-N Guidance Computer Unit     
+    #LOC_NFLaunchVehicles_nflv-drone-5-1_title                = RC-50 Guidance Computer Unit (N-Series) // R-N Guidance Computer Unit
     #LOC_NFLaunchVehicles_nflv-battery-5-1_title              = Z-K32 Rechargeable Battery Bank         // Z-32K Rechargeable Battery Bank
     #LOC_NFLaunchVehicles_nflv-docking-5-1_title              = Clamp-O-Tron Docking Port XXL 'Mondo'   // Clamp-O-Tron Mondo Docking Port
-    #LOC_NFLaunchVehicles_nflv-decoupler-5-1_title            = TD-50 Decoupler (N-Series)              // TD-500 Stack Decoupler         
-    #LOC_NFLaunchVehicles_nflv-separator-5-1_title            = TS-50 Separator (N-Series)              // TS-500 Stack Separator         
-    #LOC_NFLaunchVehicles_nflv-fairing-5-1_title              = AE-FF4 Payload Fairing (5.0m)           // AE-FF4 Payload Fairing (5.0m)  
+    #LOC_NFLaunchVehicles_nflv-decoupler-5-1_title            = TD-50 Decoupler (N-Series)              // TD-500 Stack Decoupler
+    #LOC_NFLaunchVehicles_nflv-separator-5-1_title            = TS-50 Separator (N-Series)              // TS-500 Stack Separator
+    #LOC_NFLaunchVehicles_nflv-fairing-5-1_title              = AE-FF4 Payload Fairing (5.0m)           // AE-FF4 Payload Fairing (5.0m)
 
-    #LOC_NFLaunchVehicles_nflv-skeletal-adapter-5-375-1_title = Kerbodyne S3-S4-SKL-016 Adapter       // NR-AD-SKL Adapter                  
-    #LOC_NFLaunchVehicles_nflv-adapter-5-375-1_title          = Kerbodyne S3-S4-104 Adapter Tank      // NR-AD-10400 Fuel Tank Adapter  
-    #LOC_NFLaunchVehicles_nflv-adapter-5-375-2_title          = Kerbodyne S3-S4-064 Adapter Tank      // NR-AD-6400 Fuel Tank Adapter   
-    #LOC_NFLaunchVehicles_nflv-adapter-5-375-3_title          = Kerbodyne S3-S4-026 Adapter Tank      // NR-AD-2600 Fuel Tank Adapter          
-    #LOC_NFLaunchVehicles_nflv-fueltank-nosecone-5-1_title    = Kerbodyne S4 128 Fuelled Nosecone     // NR-C-12800 Fuelled Nosecone    
-    #LOC_NFLaunchVehicles_nflv-fueltank-round-5-1_title       = Kerbodyne S4 064 Rounded Nosecone     // NR-C-6400 Rounded Nosecone   
-    #LOC_NFLaunchVehicles_nflv-fueltank-5-1_title             = Kerbodyne S4-512 Fuel Tank (N-Series) // NR-51200 Fuel Tank             
-    #LOC_NFLaunchVehicles_nflv-fueltank-5-2_title             = Kerbodyne S4-256 Fuel Tank (N-Series) // NR-25600 Fuel Tank             
-    #LOC_NFLaunchVehicles_nflv-fueltank-5-3_title             = Kerbodyne S4-128 Fuel Tank (N-Series) // NR-12800 Fuel Tank             
-    #LOC_NFLaunchVehicles_nflv-fueltank-5-4_title             = Kerbodyne S4-064 Fuel Tank (N-Series) // NR-6400 Fuel Tank              
- 
-    #LOC_NFLaunchVehicles_nflv-adapter-5-375-4_title          = Adapter 37-50 N-Series Brand           // NR-AD-CAP Adapter              
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-1_title  = Adapter 50-L1 Lower Stage Engine Mount // NR-L1 Lower Stage Engine Mount 
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-2_title  = Adapter 50-L2 Lower Stage Engine Mount // NR-L2 Lower Stage Engine Mount 
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-3_title  = Adapter 50-L3 Lower Stage Engine Mount // NR-L3 Lower Stage Engine Mount 
+    #LOC_NFLaunchVehicles_nflv-skeletal-adapter-5-375-1_title = Kerbodyne S3-S4-SKL-016 Adapter       // NR-AD-SKL Adapter
+    #LOC_NFLaunchVehicles_nflv-adapter-5-375-1_title          = Kerbodyne S3-S4-104 Adapter Tank      // NR-AD-10400 Fuel Tank Adapter
+    #LOC_NFLaunchVehicles_nflv-adapter-5-375-2_title          = Kerbodyne S3-S4-064 Adapter Tank      // NR-AD-6400 Fuel Tank Adapter
+    #LOC_NFLaunchVehicles_nflv-adapter-5-375-3_title          = Kerbodyne S3-S4-026 Adapter Tank      // NR-AD-2600 Fuel Tank Adapter
+    #LOC_NFLaunchVehicles_nflv-fueltank-nosecone-5-1_title    = Kerbodyne S4 128 Fuelled Nosecone     // NR-C-12800 Fuelled Nosecone
+    #LOC_NFLaunchVehicles_nflv-fueltank-round-5-1_title       = Kerbodyne S4 064 Rounded Nosecone     // NR-C-6400 Rounded Nosecone
+    #LOC_NFLaunchVehicles_nflv-fueltank-5-1_title             = Kerbodyne S4-512 Fuel Tank (N-Series) // NR-51200 Fuel Tank
+    #LOC_NFLaunchVehicles_nflv-fueltank-5-2_title             = Kerbodyne S4-256 Fuel Tank (N-Series) // NR-25600 Fuel Tank
+    #LOC_NFLaunchVehicles_nflv-fueltank-5-3_title             = Kerbodyne S4-128 Fuel Tank (N-Series) // NR-12800 Fuel Tank
+    #LOC_NFLaunchVehicles_nflv-fueltank-5-4_title             = Kerbodyne S4-064 Fuel Tank (N-Series) // NR-6400 Fuel Tank
+
+    #LOC_NFLaunchVehicles_nflv-adapter-5-375-4_title          = Adapter 37-50 N-Series Brand           // NR-AD-CAP Adapter
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-1_title  = Adapter 50-L1 Lower Stage Engine Mount // NR-L1 Lower Stage Engine Mount
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-2_title  = Adapter 50-L2 Lower Stage Engine Mount // NR-L2 Lower Stage Engine Mount
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-3_title  = Adapter 50-L3 Lower Stage Engine Mount // NR-L3 Lower Stage Engine Mount
     #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-4_title  = Adapter 50-L4 Lower Stage Engine Mount // NR-L4 Lower Stage Cluster Mount
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-5-1_title  = Adapter 50-U1 Upper Stage Engine Mount // NR-U1 Upper Stage Engine Mount 
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-5-2_title  = Adapter 50-U2 Upper Stage Engine Mount // NR-U2 Upper Stage Engine Mount 
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-5-3_title  = Adapter 50-U3 Upper Stage Engine Mount // NR-U3 Upper Stage Engine Mount 
-    
-    #LOC_NFLaunchVehicles_nflv-service-bay-5-1_title          = N50 Service Bay (N-Series)                 // N-Series Service Bay           
-    #LOC_NFLaunchVehicles_nflv-cargo-tube-5-1_title           = N50 Structural Decouplable Tube (N-Series) // N-Series Structural Tube   
-    #LOC_NFLaunchVehicles_nflv-cargo-5-1_title                = N50-8 Cargo Bay (N-Series)                 // NCR-8 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-5-2_title                = N50-4 Cargo Bay (N-Series)                 // NCR-4 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-5-3_title                = N50-2 Cargo Bay (N-Series)                 // NCR-2 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-5-4_title                = N50-1 Cargo Bay (N-Series)                 // NCR-1 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-nose-5-1_title           = N50-N Nose Cargo Bay (N-Series)            // NCR-N Nose Cargo Bay           
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-5-1_title  = Adapter 50-U1 Upper Stage Engine Mount // NR-U1 Upper Stage Engine Mount
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-5-2_title  = Adapter 50-U2 Upper Stage Engine Mount // NR-U2 Upper Stage Engine Mount
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-5-3_title  = Adapter 50-U3 Upper Stage Engine Mount // NR-U3 Upper Stage Engine Mount
+
+    #LOC_NFLaunchVehicles_nflv-service-bay-5-1_title          = N50 Service Bay (N-Series)                 // N-Series Service Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-tube-5-1_title           = N50 Structural Decouplable Tube (N-Series) // N-Series Structural Tube
+    #LOC_NFLaunchVehicles_nflv-cargo-5-1_title                = N50-8 Cargo Bay (N-Series)                 // NCR-8 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-5-2_title                = N50-4 Cargo Bay (N-Series)                 // NCR-4 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-5-3_title                = N50-2 Cargo Bay (N-Series)                 // NCR-2 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-5-4_title                = N50-1 Cargo Bay (N-Series)                 // NCR-1 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-nose-5-1_title           = N50-N Nose Cargo Bay (N-Series)            // NCR-N Nose Cargo Bay
 
 
     // 7.5 Metre
     // ======
-    #LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (E-Series) // R-EX Guidance Computer Unit    
+    #LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (E-Series) // R-EX Guidance Computer Unit
     #LOC_NFLaunchVehicles_nflv-battery-75-1_title             = Z-K72 Rechargeable Battery Bank         // Z-72K Rechargeable Battery Bank
-    #LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (E-Series)              // TD-750 Stack Decoupler         
-    #LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (E-Series)              // TS-750 Stack Separator         
-    #LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m)           // AE-FF5 Payload Fairing (7.5m)  
-    
-    #LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = Kerbodyne S4-S5-SKL-117 Adapter             // EA-AD-SKL Adapter  
-    #LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = Kerbodyne S4-S5-117 Adapter Tank (E-Series) // EA-S10 Fuel Tank Adapter    
-    #LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = Kerbodyne S4-S5-234 Adapter Tank (E-Series) // EA-S20 Fuel Tank Adapter       
-    #LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = Kerbodyne S5 216 Rounded Nosecone           // EA-C-64 Rounded Nosecone 
-    #LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = Kerbodyne S5 432 Fuelled Nosecone           // EA-C-128 Fuelled Nosecone      
-    #LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = Kerbodyne S5-0096 Fuel Tank (E-Series)      // EA-F96 Fuel Tank   
-    #LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = Kerbodyne S5-0192 Fuel Tank (E-Series)      // EA-F192 Fuel Tank  
-    #LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = Kerbodyne S5-0384 Fuel Tank (E-Series)      // EA-F384 Fuel Tank 
-    #LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = Kerbodyne S5-0768 Fuel Tank (E-Series)      // EA-F768 Fuel Tank                       
-    #LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = Kerbodyne S5-1536 Fuel Tank (E-Series)      // EA-F1536 Fuel Tank     
-    
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-1_title = Adapter 75-L1 Lower Stage Engine Mount     // ER-L1 Lower Stage Engine Mount 
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-2_title = Adapter 75-L2 Lower Stage Engine Mount     // ER-L2 Lower Stage Engine Mount 
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-1_title = Adapter 75-U1 Upper Stage Engine Mount     // ER-U1 Upper Stage Engine Mount 
-    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-2_title = Adapter 75-U2 Upper Stage Engine Mount     // ER-U2 Upper Stage Engine Mount 
+    #LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (E-Series)              // TD-750 Stack Decoupler
+    #LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (E-Series)              // TS-750 Stack Separator
+    #LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m)           // AE-FF5 Payload Fairing (7.5m)
 
-    #LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (E-Series) // E-Series Structural Tube           
-    #LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (E-Series)                 // E-Series Service Bay           
-    #LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (E-Series)                 // ECR-8 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (E-Series)                 // ECR-4 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (E-Series)                 // ECR-2 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (E-Series)                 // ECR-1 Cargo Bay                
-    #LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (E-Series)            // ECR-N Nose Cargo Bay           
-      
+    #LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = Kerbodyne S4-S5-SKL-117 Adapter             // EA-AD-SKL Adapter
+    #LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = Kerbodyne S4-S5-117 Adapter Tank (E-Series) // EA-S10 Fuel Tank Adapter
+    #LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = Kerbodyne S4-S5-234 Adapter Tank (E-Series) // EA-S20 Fuel Tank Adapter
+    #LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = Kerbodyne S5 216 Rounded Nosecone           // EA-C-64 Rounded Nosecone
+    #LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = Kerbodyne S5 432 Fuelled Nosecone           // EA-C-128 Fuelled Nosecone
+    #LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = Kerbodyne S5-0096 Fuel Tank (E-Series)      // EA-F96 Fuel Tank
+    #LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = Kerbodyne S5-0192 Fuel Tank (E-Series)      // EA-F192 Fuel Tank
+    #LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = Kerbodyne S5-0384 Fuel Tank (E-Series)      // EA-F384 Fuel Tank
+    #LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = Kerbodyne S5-0768 Fuel Tank (E-Series)      // EA-F768 Fuel Tank
+    #LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = Kerbodyne S5-1536 Fuel Tank (E-Series)      // EA-F1536 Fuel Tank
+
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-1_title = Adapter 75-L1 Lower Stage Engine Mount     // ER-L1 Lower Stage Engine Mount
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-2_title = Adapter 75-L2 Lower Stage Engine Mount     // ER-L2 Lower Stage Engine Mount
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-1_title = Adapter 75-U1 Upper Stage Engine Mount     // ER-U1 Upper Stage Engine Mount
+    #LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-2_title = Adapter 75-U2 Upper Stage Engine Mount     // ER-U2 Upper Stage Engine Mount
+
+    #LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (E-Series) // E-Series Structural Tube
+    #LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (E-Series)                 // E-Series Service Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (E-Series)                 // ECR-8 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (E-Series)                 // ECR-4 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (E-Series)                 // ECR-2 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (E-Series)                 // ECR-1 Cargo Bay
+    #LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (E-Series)            // ECR-N Nose Cargo Bay
+
 
     // Support
     =========
@@ -164,41 +164,40 @@ Localization
 
     // New Engines
     // =====
-    #LOC_NFLaunchVehicles_engine-rutherford-1_title     = KS-1E 'Goldfish' Liquid Fuel Engine   // KS-1E 'Goldfish' Liquid Fuel Engine  
-    #LOC_NFLaunchVehicles_engine-m1d-1_title            = KS-1M 'Otter' Liquid Fuel Engine      // KS-1M 'Otter' Liquid Fuel Engine     
-    #LOC_NFLaunchVehicles_engine-ar1-1_title            = KS-10AJ 'Walrus' Liquid Fuel Engine   // KS-10AJ 'Walrus' Liquid Fuel Engine  
-    #LOC_NFLaunchVehicles_engine-stbe-1_title           = KS-60 'Orca' Liquid Fuel Engine // KS-60 'Orca' Liquid Fuel Engine
-    #LOC_NFLaunchVehicles_engine-tr107-1_title          = KS-107 'Porpoise' Liquid Fuel Engine  // KS-107 'Porpoise' Liquid Fuel Engine 
-    #LOC_NFLaunchVehicles_engine-stbe-kero-1_title      = KS-160 'Orca' Liquid Fuel Engine      // KS-160 'Orca' Liquid Fuel Engine     
-    #LOC_NFLaunchVehicles_engine-ar1c-1_title           = KS-600AJ 'Manatee' Liquid Fuel Engine // KS-600AJ 'Manatee' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-rutherford-1_title     = KS-06E 'Goldfish' Liquid Fuel Engine   // KS-1E 'Goldfish' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-m1d-1_title            = KS-06M 'Otter' Liquid Fuel Engine      // KS-1M 'Otter' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-ar1-1_title            = KS-12 'Walrus' Liquid Fuel Engine      // KS-10AJ 'Walrus' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-tr107-1_title          = KS-18 'Porpoise' Liquid Fuel Engine    // KS-107 'Porpoise' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-stbe-kero-1_title      = KS-25 'Orca' Liquid Fuel Engine        // KS-160 'Orca' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-ar1c-1_title           = KS-37 'Manatee' Liquid Fuel Engine     // KS-600AJ 'Manatee' Liquid Fuel Engine
 
-    #LOC_NFLaunchVehicles_engine-rutherford-vac-1_title = KR-1E-V 'Angora' Liquid Fuel Engine   // KR-1E-V 'Angora' Liquid Fuel Engine  
-    #LOC_NFLaunchVehicles_engine-m1d-vac-1_title        = KR-1M-V 'Sphinx' Liquid Fuel Engine   // KR-1M-V 'Sphinx' Liquid Fuel Engine  
-    #LOC_NFLaunchVehicles_engine-rd704-1_title          = KR-74 'Lynx' Liquid Fuel Engine       // KR-74 'Lynx' Liquid Fuel Engine      
-    #LOC_NFLaunchVehicles_engine-rs84-1_title           = KR-84 'Ocelot' Liquid Fuel Engine     // KR-84 'Ocelot' Liquid Fuel Engine    
-    #LOC_NFLaunchVehicles_engine-rd701-1_title          = KR-701 'Cougar' Liquid Fuel Engine    // KR-701 'Cougar' Liquid Fuel Engine   
+    #LOC_NFLaunchVehicles_engine-rutherford-vac-1_title = KR-06 'Angora' Liquid Fuel Engine      // KR-1E-V 'Angora' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-m1d-vac-1_title        = KR-12 'Sphinx' Liquid Fuel Engine      // KR-1M-V 'Sphinx' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-rd704-1_title          = KR-18 'Lynx' Liquid Fuel Engine        // KR-74 'Lynx' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-rs84-1_title           = KR-25 'Ocelot' Liquid Fuel Engine      // KR-84 'Ocelot' Liquid Fuel Engine
+    #LOC_NFLaunchVehicles_engine-rd701-1_title          = KR-37 'Cougar' Liquid Fuel Engine      // KR-701 'Cougar' Liquid Fuel Engine
 
 
 
     // RCS
     // ======
-    #LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-1_title             = RX-5x1 Heavy RCS Thruster                        // RQ-5x1 Heavy RCS Thruster                       
-    #LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-1_title             = RX-5x4 Heavy RCS Block                           // RQ-5x4 Heavy RCS Block                          
-    #LOC_NFLaunchVehicles_nflv-rcs-aero-heavy-1_title           = RX-5x4-A Aerodynamic Heavy RCS Block               // RQ-5-A Aerodynamic Heavy RCS Block  
-    
-    #LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-2_title             = RX-88x1 Heavy Bipropellant RCS Thruster          // RJ-88x1 Heavy Bipropellant RCS Thruster         
-    #LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-2_title             = RX-88x4 Heavy Bipropellant RCS Block             // RJ-88x4 Heavy Bipropellant RCS Block            
+    #LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-1_title             = RX-5x1 Heavy RCS Thruster                        // RQ-5x1 Heavy RCS Thruster
+    #LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-1_title             = RX-5x4 Heavy RCS Block                           // RQ-5x4 Heavy RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-aero-heavy-1_title           = RX-5x4-A Aerodynamic Heavy RCS Block               // RQ-5-A Aerodynamic Heavy RCS Block
+
+    #LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-2_title             = RX-88x1 Heavy Bipropellant RCS Thruster          // RJ-88x1 Heavy Bipropellant RCS Thruster
+    #LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-2_title             = RX-88x4 Heavy Bipropellant RCS Block             // RJ-88x4 Heavy Bipropellant RCS Block
     #LOC_NFLaunchVehicles_nflv-rcs-aero-heavy-2_title           = RX-88x4-A Aerodynamic Heavy Bipropellant RCS Block // RJ-88-A Aerodynamic Heavy Bipropellant RCS Block
-      
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-1_title        = VS-4 Integrated RCS Block                      // AVCS-4 Integrated RCS Block                     
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-2_title        = VS-4A Integrated RCS Block                     // AVCS-4A Integrated RCS Block                    
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-3x-1_title        = VS-3 Integrated RCS Block                      // AVCS-3 Integrated RCS Block                                                       
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-1_title    = VS-LH-4 Integrated RCS Block                   // AVCS-LH-4 Integrated RCS Block                  
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-2_title    = VS-LH-4A Integrated RCS Block                  // AVCS-LH-4A Integrated RCS Block                 
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-3x-1_title    = VS-LH-3 Integrated RCS Block                   // AVCS-LH-3 Integrated RCS Block                  
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-4x-1_title   = VS-CH4-4 Integrated RCS Block                  // AVCS-CH4-4 Integrated RCS Block                 
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-4x-2_title   = VS-CH4-4A Integrated RCS Block                 // AVCS-CH4-4A Integrated RCS Block                
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-3x-1_title   = VS-CH4-3 Integrated RCS Block                  // AVCS-CH4-3 Integrated RCS Block                 
+
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-1_title        = VS-4 Integrated RCS Block                      // AVCS-4 Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-2_title        = VS-4A Integrated RCS Block                     // AVCS-4A Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-3x-1_title        = VS-3 Integrated RCS Block                      // AVCS-3 Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-1_title    = VS-LH-4 Integrated RCS Block                   // AVCS-LH-4 Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-2_title    = VS-LH-4A Integrated RCS Block                  // AVCS-LH-4A Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-3x-1_title    = VS-LH-3 Integrated RCS Block                   // AVCS-LH-3 Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-4x-1_title   = VS-CH4-4 Integrated RCS Block                  // AVCS-CH4-4 Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-4x-2_title   = VS-CH4-4A Integrated RCS Block                 // AVCS-CH4-4A Integrated RCS Block
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-3x-1_title   = VS-CH4-3 Integrated RCS Block                  // AVCS-CH4-3 Integrated RCS Block
 
 
 
@@ -257,7 +256,7 @@ Localization
     #LOC_NFLaunchVehicles_decoupler-75-1_title     = TD-75 Decoupler (E-Series)                    // TR-750 Stack Decoupler
     #LOC_NFLaunchVehicles_fairing-75-1_title       = AE-FF5 Payload Fairing (7.5m)                 // AE-FF5 Payload Fairing (7.5m)
 
-    #LOC_NFLaunchVehicles_service-bay-75-1_title = N75 Service Bay (E-Series)      
+    #LOC_NFLaunchVehicles_service-bay-75-1_title = N75 Service Bay (E-Series)
     #LOC_NFLaunchVehicles_cargo-75-1_title =       N75-8 Cargo Bay (E-Series)
     #LOC_NFLaunchVehicles_cargo-75-2_title =       N75-4 Cargo Bay (E-Series)
     #LOC_NFLaunchVehicles_cargo-75-3_title =       N75-2 Cargo Bay (E-Series)

--- a/GameData/002_CommunityPartsTitles/Localization/loc_nf-spacecraft_nf-launch-vehicles.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/loc_nf-spacecraft_nf-launch-vehicles.cfg
@@ -196,9 +196,9 @@ Localization
     #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-1_title    = VS-LH-4 Integrated RCS Block                   // AVCS-LH-4 Integrated RCS Block                  
     #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-2_title    = VS-LH-4A Integrated RCS Block                  // AVCS-LH-4A Integrated RCS Block                 
     #LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-3x-1_title    = VS-LH-3 Integrated RCS Block                   // AVCS-LH-3 Integrated RCS Block                  
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-ch4-4x-1_title    = VS-CH4-4 Integrated RCS Block                  // AVCS-CH4-4 Integrated RCS Block                 
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-ch4-4x-2_title    = VS-CH4-4A Integrated RCS Block                 // AVCS-CH4-4A Integrated RCS Block                
-    #LOC_NFLaunchVehicles_nflv-rcs-integrated-ch4-3x-1_title    = VS-CH4-3 Integrated RCS Block                  // AVCS-CH4-3 Integrated RCS Block                 
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-4x-1_title   = VS-CH4-4 Integrated RCS Block                  // AVCS-CH4-4 Integrated RCS Block                 
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-4x-2_title   = VS-CH4-4A Integrated RCS Block                 // AVCS-CH4-4A Integrated RCS Block                
+    #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-3x-1_title   = VS-CH4-3 Integrated RCS Block                  // AVCS-CH4-3 Integrated RCS Block                 
 
 
 


### PR DESCRIPTION
- Addressed NFLV engine sorting (these lines were already present in the cfg, but unchanged from default)
- Added new CryoEngines methalox engines
- Fixed typo in NFLV methalox RCS variants