### PR TITLE
FFT, SystemHeat, KRE

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/loc_fft.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/loc_fft.cfg
@@ -1,0 +1,86 @@
+Localization
+{
+  en-us
+  {
+    // // Engines
+    // // ===========
+    // // Fusion Pulse
+    // #LOC_FFT_fft-fusion-magnetic-inertial-1_title = JP-10 'Impulse' Magneto-Inertial Fusion Engine
+    // #LOC_FFT_fft-fusion-inertial-laser-1_title =  K-80 'Hammertong' Inertial Confinement Fusion Engine
+    //
+    // // Thermal Fusion
+    // #LOC_FFT_fft-fusion-magnetic-tokamak-1_title = JR-15 'Discovery' Spherical Tokamak Fusion Engine
+    // #LOC_FFT_fft-fusion-magnetic-mirror-1_title = JR-45 'Fresnel' Mirror Cell Fusion Engine
+    // #LOC_FFT_fft-fusion-magnetic-tokamak-aerospike-1_title = JR-20A 'Ouroboros' Toroidal Tokamak Fusion Engine
+    // #LOC_FFT_fft-fusion-axial-zpinch-1_title =  JX-200 'Cascade' Axial Flow Z-Pinch Fusion Engine
+    //
+    // // Super exotic
+    // #LOC_FFT_fft-nswr-1_title = X-2 'Heinlein' Nuclear Salt Water Rocket Engine
+    // #LOC_FFT_fft-nswr-2_title = X-50 'Niven' Nuclear Salt Water Rocket Engine
+    //
+    // // Fission
+    // #LOC_FFT_fft-ffre-solid-1_title = X-6 'Clarke' Fission Fragment Rocket Engine
+    // #LOC_FFT_fft-ffre-plasma-1_title = X-7 'Asimov' Afterburning Fission Fragment Rocket Engine
+    // #LOC_FFT_fft-fission-zpinch-1_title = X-20 'Verne' Pulsed Fission Engine
+    //
+    // // Antimatter
+    // #LOC_FFT_fft-antimatter-microfission-1_title = A-134NG 'Casaba' Antimatter Catalyzed Microfission Engine
+    // #LOC_FFT_fft-antimatter-microfusion-1_title = A-7007 'Dirac' Antimatter Initiated Microfusion Engine
+    // #LOC_FFT_fft-antimatter-beam-1_title = A-834M 'Frisbee' Antimatter Engine
+
+    // Tanks
+    // ===========
+    // Fusion Fuel
+    #LOC_FFT_fft-fueltank-fusion-25-1_title =  ST-25-412 Fusion Fuel Tank   // ST-412
+    #LOC_FFT_fft-fueltank-fusion-25-2_title =  ST-25-824 Fusion Fuel Tank   // ST-824
+    #LOC_FFT_fft-fueltank-fusion-375-1_title = ST-37-4L3 Fusion Fuel Tank   // ST-4L3
+    #LOC_FFT_fft-fueltank-fusion-375-2_title = ST-37-4L3R Fusion Fuel Tank  // ST-4L3R
+
+    // // Targets
+    // #LOC_FFT_fft-fueltank-targets-5-1_title = PW x4 Nuclear Pellet Storage Container
+
+    // Fission Fuel
+    #LOC_FFT_fft-fueltank-fission-25-3_title =     NTS-A Fissonables Tank        // NTS-003
+    #LOC_FFT_fft-fueltank-fission-25-2_title =     NTS-B Fissonables Tank        // NTS-002
+    #LOC_FFT_fft-fueltank-fission-25-1_title =     NTS-C Fissonables Tank        // NTS-001
+
+    #LOC_FFT_fft-fueltank-fission-radial-3_title = NTR-A Radial Fissonables Tank // NTR-003
+    #LOC_FFT_fft-fueltank-fission-radial-2_title = NTR-B Radial Fissonables Tank // NTR-002
+    #LOC_FFT_fft-fueltank-fission-radial-1_title = NTR-C Radial Fissonables Tank // NTR-001
+
+    // Lithium
+    #LOC_FFT_fft-fueltank-lithium-25-3_title =          LFT-25-09 Lithium Tank  // LFT-A10
+    #LOC_FFT_fft-fueltank-lithium-25-2_title =          LFT-25-18 Lithium Tank  // LFT-A20
+    #LOC_FFT_fft-fueltank-lithium-25-1_title =          LFT-25-35 Lithium Tank  // LFT-A40
+    #LOC_FFT_fft-fueltank-lithium-radial-125-1_title =  LFR-092 Lithium Tank    // LFR-08
+    #LOC_FFT_fft-fueltank-lithium-radial-0625-1_title = LFR-880 Lithium Tank    // LFR-01
+
+    // // Antimatter
+    // #LOC_FFT_fft-fueltank-antimatter-ring-75-1_title = A-R7NG Antiproton Storage Ring
+    // #LOC_FFT_fft-fueltank-antimatter-tank-5-1_title =  A-CY1-5 Antimatter Storage Container
+    // #LOC_FFT_fft-fueltank-antimatter-tank-25-1_title = A-CY1-25XL Antimatter Storage Container
+    // #LOC_FFT_fft-fueltank-antimatter-tank-25-2_title = A-CY1-25 Antimatter Storage Container
+
+    // // Power Generation
+    // // ====================
+    // // Reactors
+    // #LOC_FFT_fft-fusion-reactor-25-1_title =  FX-2 Fusion Reactor
+    // #LOC_FFT_fft-fusion-reactor-375-1_title = FX-3 Fusion Reactor
+    //
+    // // Resources
+    // // ====================
+    // // Detectors
+    // #LOC_FFT_fft-scanner-gas-1_title =        CHROMA Imaging Spectrometer
+    // #LOC_FFT_fft-scanner-antimatter-1_title = CRANE Gamma Ray Spectrometer
+    //
+    // // Harvesters
+    // #LOC_FFT_fft-scoop-atmosphere-1_title = PK-ATMO 'Hoover' Atmospheric Ramscoop
+    // #LOC_FFT_fft-scoop-exosphere-1_title =  PK-EXO 'Bussard' Particle Scoop
+    // #LOC_FFT_fft-scoop-regolith-1_title =   PK-DUST Regolith Processing System
+    // #LOC_FFT_fft-scoop-regolith-2_title =   PK-DUST-S Regolith Processing System
+    //
+    // // Processors
+    // #LOC_FFT_fft-nuclear-smelter-375-1_title = PK-1 'Vulcan' Nuclear Smelter
+    // #LOC_FFT_fft-antimatter-factory-1_title =  PK-50 'Nova' Antimatter Facility
+  }
+}

--- a/GameData/002_CommunityPartsTitles/Localization/loc_heat-control.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/loc_heat-control.cfg
@@ -15,15 +15,15 @@ Localization
     #LOC_HeatControl_radiator-fixed-2_title = XE-0025 'Alpha' High Temperature Radiator Fin  // VF-25
     #LOC_HeatControl_radiator-fixed-1_title = XE-0150 'Beta' High Temperature Heat Radiator  // VF-150
     #LOC_HeatControl_radiator-fixed-3_title = XE-0600 'Gamma' High Temperature Heat Radiator  // VF-600
-    #LOC_HeatControl_radiator-fixed-4_title =  XE-2000 'Delta' High Temperature Heat Radiator  // VF-2000
+    #LOC_HeatControl_radiator-fixed-4_title = XE-2000 'Delta' High Temperature Heat Radiator  // VF-2000
 
     #LOC_HeatControl_radiator-fixed-3_description = The Gamma radiator was forged in the heat of Mount Doom, and as a result it can reject a real lot of heat.
     #LOC_HeatControl_radiator-fixed-4_description = The massive Delta radiator is a powerful tool in any space program's heat management arsenal.
 
     // Curved Radiators
-    #LOC_HeatControl_radiator-surface-125-1_title = XF-12-25 'Ezikiel' High Temperature Heat Radiator
-    #LOC_HeatControl_radiator-surface-25-1_title  = XF-25-75 'Volta' High Temperature Heat Radiator
-    #LOC_HeatControl_radiator-surface-375-1_title = XF-37-150 'Amos' High Temperature Heat Radiator
+    #LOC_HeatControl_radiator-surface-125-1_title = XF-12-25 'Ezikiel' High Temperature Heat Radiator // YF-25
+    #LOC_HeatControl_radiator-surface-25-1_title  = XF-25-75 'Volta' High Temperature Heat Radiator   // YF-75
+    #LOC_HeatControl_radiator-surface-375-1_title = XF-37-150 'Amos' High Temperature Heat Radiator   // YF-150
 
     #LOC_HeatControl_radiator-surface-125-1_description = The XF series radiators are designed to fit smoothly against spacecraft fuselages. They sacrifice some cooling capacity for this. This model fits 1.25m fuselages.
     #LOC_HeatControl_radiator-surface-25-1_description = The XF series radiators are designed to fit smoothly against spacecraft fuselages. They sacrifice some cooling capacity for this. This model fits 2.5m fuselages.
@@ -44,6 +44,43 @@ Localization
     #LOC_HeatControl_radiator-microchannel-2_title = YF-8K Microchannel Graphene Heat Radiator  // DF-8K
     #LOC_HeatControl_radiator-microchannel-fixed-1_title = YF-2K Microchannel Graphene Heat Radiator Panel  // EF-2K
     #LOC_HeatControl_radiator-microchannel-fixed-2_title = YF-1K Microchannel Graphene Heat Radiator Panel  // EF-1K
+
+    // ===========
+    // SYSTEM HEAT
+    // ===========
+
+    // // New Parts
+    // #LOC_SystemHeat_systemheat-exchanger-1_title = PX-1F Heat Exchanger           // PX-1F
+    // #LOC_SystemHeat_systemheat-coolant-tank-radial-1_title = PK-15 Coolant Tank   // PK-15
+    // #LOC_SystemHeat_systemheat-sink-1_title = PSK-200 Heat Sink                   // PSK-200
+    // #LOC_SystemHeat_systemheat-nuclear-container-1_title = Nuclear Fuel Cylinder  // Nuclear Fuel Cylinder
+
+    // Curved Radiators
+    #LOC_SystemHeat_radiator-surface-125-1_title = XF-12-07 'Ezikiel' High Temperature Heat Radiator  // YF-7
+    #LOC_SystemHeat_radiator-surface-25-1_title  = XF-25-15 'Volta' High Temperature Heat Radiator    // YF-15
+    #LOC_SystemHeat_radiator-surface-375-1_title = XF-37-25 'Amos' High Temperature Heat Radiator     // YF-25
+
+    // Fixed radiators
+    #LOC_SystemHeat_radiator-fixed-2_title = XE-0008 'Alpha' High Temperature Radiator Fin    // VF-8
+    #LOC_SystemHeat_radiator-fixed-1_title = XE-0060 'Beta' High Temperature Heat Radiator    // VF-60
+    #LOC_SystemHeat_radiator-fixed-3_title = XE-0325 'Gamma' High Temperature Heat Radiator   // VF-325
+    #LOC_SystemHeat_radiator-fixed-4_title = XE-1250 'Delta' High Temperature Heat Radiator   // VF-1250
+
+    // Conformal Radiators
+    #LOC_SystemHeat_radiator-conformal-1_title = XG-0025 High Temperature Heat Radiator   // GR-25
+    #LOC_SystemHeat_radiator-conformal-2_title = XG-0050 High Temperature Heat Radiator   // GR-50
+    #LOC_SystemHeat_radiator-conformal-3_title = XG-1125 High Temperature Heat Radiator   // GR-1125
+
+    // Deployable radiators
+    #LOC_SystemHeat_radiator-universal-1_title = XV-175 High Temperature Heat Radiator  // XR-175
+    #LOC_SystemHeat_radiator-universal-2_title = XV-500 High Temperature Heat Radiator  // XR-500
+    #LOC_SystemHeat_radiator-universal-3_title = XV-600 High Temperature Heat Radiator  // XR-600
+
+    // Microchannel Radiators
+    #LOC_SystemHeat_radiator-microchannel-fixed-2_title = YF-1K Microchannel Graphene Heat Radiator Panel   // EF-1K
+    #LOC_SystemHeat_radiator-microchannel-fixed-1_title = YF-2K Microchannel Graphene Heat Radiator Panel   // EF-2K
+    #LOC_SystemHeat_radiator-microchannel-1_title       = YF-3.25K Microchannel Graphene Heat Radiator      // DF-3.25K
+    #LOC_SystemHeat_radiator-microchannel-2_title       = YF-6.5K Microchannel Graphene Heat Radiator       // DF-6.5K
 
   }
 }

--- a/GameData/002_CommunityPartsTitles/Localization/patch_kre.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/patch_kre.cfg
@@ -1,0 +1,45 @@
+// Fuel Tank
+@PART[DragonFuelTank]:NEEDS[KerbalReusabilityExpansion]         {@title = FX-04 Dragon Fuel Tank} // Dragon Fuel Tank
+
+// // Engines
+// @PART[SmallCapsuleEngine]:NEEDS[KerbalReusabilityExpansion]     {@title = SuperDraco Engine}      // SuperDraco Engine
+// @PART[SmallCapsuleEngineRCS]:NEEDS[KerbalReusabilityExpansion]  {@title = SuperDraco Engine RCS}  // SuperDraco Engine RCS
+
+// Command & Control
+@PART[HotGasThruster-M]:NEEDS[KerbalReusabilityExpansion]       {@title = Vernier Thruster, Advanced 1M} // Advanced Vernier Thruster Medium
+@PART[HotGasThruster-L]:NEEDS[KerbalReusabilityExpansion]       {@title = Vernier Thruster, Advanced 2L} // Advanced Vernier Thruster Large
+
+// Coupling
+@PART[CapsuleDockingPort1]:NEEDS[KerbalReusabilityExpansion]    {@title = Clamp-O-Tron Docking Port (Mr, Aerodynamic)}  // Aerodynamic Docking Port
+
+// Payload
+@PART[TrunkServiceModule]:NEEDS[KerbalReusabilityExpansion]     {@title = SM-25-D Service Trunk} // Trunk
+
+// Aerodynamics
+@PART[TrunkFin]:NEEDS[KerbalReusabilityExpansion]               {@title = AV-B2 Trunk Fin}                // Trunk Fin
+@PART[BoosterWingKRE]:NEEDS[KerbalReusabilityExpansion]         {@title = Wing Deployable}                // Deployable Wing
+@PART[BoosterWingsMountKRE]:NEEDS[KerbalReusabilityExpansion]   {@title = Wing Deployable, Base}          // Deployable Wing Base
+@PART[Grid?Fin?S]:NEEDS[KerbalReusabilityExpansion]             {@title = T-01 Grid Fin Small}            // Grid Fin Small
+@PART[Grid?Fin?M]:NEEDS[KerbalReusabilityExpansion]             {@title = T-02 Grid Fin Medium}           // Grid Fin Medium
+@PART[Grid?Fin?L]:NEEDS[KerbalReusabilityExpansion]             {@title = T-03 Grid Fin Large}            // Grid Fin Large
+@PART[Grid?Fin?S?Titanium]:NEEDS[KerbalReusabilityExpansion]    {@title = T-11 "Nemesis" Grid Fin Small}  // T-222 "Nemesis" Grid Fin Small
+@PART[Grid?Fin?M?Titanium]:NEEDS[KerbalReusabilityExpansion]    {@title = T-22 "Nemesis" Grid Fin Medium} // T-222 "Nemesis" Grid Fin Medium
+@PART[Grid?Fin?L?Titanium]:NEEDS[KerbalReusabilityExpansion]    {@title = T-33 "Nemesis" Grid Fin Large}  // T-222 "Nemesis" Grid Fin Large
+
+// Ground
+@PART[KRE-AeroLeg-M]:NEEDS[KerbalReusabilityExpansion]          {@title = LT-37 Landing Gear}                      // LT-37M Landing Gear
+@PART[KRE-AeroLeg-L]:NEEDS[KerbalReusabilityExpansion]          {@title = LT-50 Landing Gear}                      // LT-37L Landing Gear
+@PART[KRE-FalconLeg-S]:NEEDS[KerbalReusabilityExpansion]        {@title = LT-F1-12 Falcon Landing Gear Small}      // Falcon Landing Gear Small
+@PART[KRE-FalconLeg-M]:NEEDS[KerbalReusabilityExpansion]        {@title = LT-F1-25 Falcon Landing Gear Medium}     // Falcon Landing Gear Medium
+@PART[KRE-FalconLeg-L]:NEEDS[KerbalReusabilityExpansion]        {@title = LT-F1-37 Falcon Landing Gear Large}      // Falcon Landing Gear Large
+@PART[KRE-FalconLegMk2-M]:NEEDS[KerbalReusabilityExpansion]     {@title = LT-F2-25 Falcon Landing Gear Mk2 Medium} // Falcon Landing Gear Mk2 Medium
+@PART[KRE-FalconLegMk2-L]:NEEDS[KerbalReusabilityExpansion]     {@title = LT-F2-37 Falcon Landing Gear Mk2 Large}  // Falcon Landing Gear Mk2 Large
+@PART[KRE-HexLegsM]:NEEDS[KerbalReusabilityExpansion]           {@title = LT-GL-25 Glenn Legs Medium}              // Glenn Legs Medium
+@PART[KRE-HexLegsL]:NEEDS[KerbalReusabilityExpansion]           {@title = LT-GL-37 Glenn Legs Large}               // Glenn Legs Large
+@PART[KRE-HexLegsMountM]:NEEDS[KerbalReusabilityExpansion]      {@title = LT-GM-25 Glenn Leg Mount Medium}         // Glenn Leg Mount Medium
+@PART[KRE-HexLegsMountL]:NEEDS[KerbalReusabilityExpansion]      {@title = LT-GM-37 Glenn Leg Mount Large}          // Glenn Leg Mount Large
+@PART[KRE-ShepardLeg-S]:NEEDS[KerbalReusabilityExpansion]       {@title = LT-NS-12 New Shepard Landing Leg Small}  // New Shepard Landing Leg Small
+@PART[KRE-ShepardLeg-M]:NEEDS[KerbalReusabilityExpansion]       {@title = LT-NS-25 New Shepard Landing Leg Medium} // New Shepard Landing Leg Medium
+
+// Thermal
+@PART[Heatshield-M]:NEEDS[KerbalReusabilityExpansion]           {@title = Heat Shield (2.5m Dragon)} // Dragon Heat Shield


### PR DESCRIPTION
Add support for:

- SystemHeat, which changes the titles of Heat Control radiators. This change unifies CPT's prefixes to sort HC parts with SH's numeric indicators for cooling capacity in its system.
- Far Future Technologies. Most parts were left unchanged, but several fuel tanks were sorted.
- Kerbal Reusability Expansion. Part titles were changed according to convention to sort with stock, etc. In particular prefixes were added to all landing legs.