### PR TITLE
Update for CryoEngines 2.0.0

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/loc_atomic_cryo.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/loc_atomic_cryo.cfg
@@ -18,27 +18,27 @@ Localization
     #LOC_KerbalAtomics_ntr-sc-375-1_title =  LV-NGZ 'Scylla' Atomic Aerospike Rocket             // NV-DC
 
 	 // CryoEngines
-    #LOC_CryoEngines_cryoengine-stromboli-1_title = CLR-06-10A 'Stromboli' Cryogenic Rocket Engine        // CR-10A
-    #LOC_CryoEngines_cryoengine-vesuvius-1_title  = CLR-12-2 'Vesuvius' Cryogenic Rocket Engine           // CR-2
-    #LOC_CryoEngines_cryoengine-hecate-1_title    = CLE-12-10 'Hecate' Cryogenic Rocket Engine            // CE-10
-    #LOC_CryoEngines_cryoengine-erebus-1_title    = CLR-18-0120 'Erebus' Cryogenic Rocket Engine          // CR-0120
-    #LOC_CryoEngines_cryoengine-pavonis-1_title   = CLE-18-60 'Pavonis' Cryogenic Rocket Engine           // CE-60
-    #LOC_CryoEngines_cryoengine-fuji-1_title      = CLR-25-9B 'Fuji' Cryogenic Rocket Engine              // CR-9B
-    #LOC_CryoEngines_cryoengine-ulysses-1_title   = CLE-25-2X 'Ulysses' Cryogenic Rocket Engine           // CE-2X
-    #LOC_CryoEngines_cryoengine-etna-1_title      = CLR-37-68 'Etna' Cryogenic Rocket Engine              // CR-68
-    #LOC_CryoEngines_cryoengine-tharsis-1_title   = CLE-37-60 'Tharsis' Cryogenic Rocket Engine Cluster   // CE-60
+    #LOC_CryoEngines_cryoengine-stromboli-1_title = CLR-06-10A 'Stromboli' Liquid Hydrogen Engine        // CR-10A
+    #LOC_CryoEngines_cryoengine-vesuvius-1_title  = CLR-12-2 'Vesuvius' Liquid Hydrogen Engine           // CR-2
+    #LOC_CryoEngines_cryoengine-hecate-1_title    = CLE-12-10 'Hecate' Liquid Hydrogen Engine            // CE-10
+    #LOC_CryoEngines_cryoengine-erebus-1_title    = CLR-18-0120 'Erebus' Liquid Hydrogen Engine          // CR-0120
+    #LOC_CryoEngines_cryoengine-pavonis-1_title   = CLE-18-60 'Pavonis' Liquid Hydrogen Engine           // CE-60
+    #LOC_CryoEngines_cryoengine-fuji-1_title      = CLR-25-9B 'Fuji' Liquid Hydrogen Engine              // CR-9B
+    #LOC_CryoEngines_cryoengine-ulysses-1_title   = CLE-25-2X 'Ulysses' Liquid Hydrogen Engine           // CE-2X
+    #LOC_CryoEngines_cryoengine-etna-1_title      = CLR-37-68 'Etna' Liquid Hydrogen Engine              // CR-68
+    #LOC_CryoEngines_cryoengine-tharsis-1_title   = CLE-37-60 'Tharsis' Liquid Hydrogen Engine Cluster   // CE-60
 
     // CryoEngines Methalox
-    #LOC_CryoEngines_cryoengine-compsognathus-1_title = CMR-06-1 'Compsognathus' Liquid Rocket Engine           // MR-1
-    #LOC_CryoEngines_cryoengine-hawk-1_title          = CME-06-018 'Hawk' Liquid Rocket Engine                  // MU-018
-    #LOC_CryoEngines_cryoengine-deinonychus-1_title   = CMR-12-420 'Deinonychus' Liquid Rocket Engine           // MR-420
-    #LOC_CryoEngines_cryoengine-buzzard-1_title       = CME-12-10 'Buzzard' Liquid Rocket Engine                // MU-10
-    #LOC_CryoEngines_cryoengine-iguanodon-1_title     = CMR-18-4 'Iguanodon' Liquid Rocket Engine               // MR-4
-    #LOC_CryoEngines_cryoengine-harrier-1_title       = CME-18-11 'Harrier' Liquid Rocket Engine                // MU-11
-    #LOC_CryoEngines_cryoengine-allosaur-1_title      = CMR-25-8 'Allosaur' Liquid Rocket Engine                // MR-8
-    #LOC_CryoEngines_cryoengine-eagle-1_title         = CME-25-421 'Eagle' Liquid Rocket Engine                 // MU-421
-    #LOC_CryoEngines_cryoengine-tyrannosaur-1_title   = CMR-37-4209 'Tyrannosaur' Liquid Rocket Engine Cluster  // MR-420-9
-    #LOC_CryoEngines_cryoengine-vulture-1_title       = CME-37-4U 'Vulture' Liquid Rocket Engine                // MU-4U
+    #LOC_CryoEngines_cryoengine-compsognathus-1_title = CMR-06-1 'Compsognathus' Liquid Methane Engine           // MR-1
+    #LOC_CryoEngines_cryoengine-hawk-1_title          = CME-06-018 'Hawk' Liquid Methane Engine                  // MU-018
+    #LOC_CryoEngines_cryoengine-deinonychus-1_title   = CMR-12-420 'Deinonychus' Liquid Methane Engine           // MR-420
+    #LOC_CryoEngines_cryoengine-buzzard-1_title       = CME-12-10 'Buzzard' Liquid Methane Engine                // MU-10
+    #LOC_CryoEngines_cryoengine-iguanodon-1_title     = CMR-18-4 'Iguanodon' Liquid Methane Engine               // MR-4
+    #LOC_CryoEngines_cryoengine-harrier-1_title       = CME-18-11 'Harrier' Liquid Methane Engine                // MU-11
+    #LOC_CryoEngines_cryoengine-allosaur-1_title      = CMR-25-8 'Allosaur' Liquid Methane Engine                // MR-8
+    #LOC_CryoEngines_cryoengine-eagle-1_title         = CME-25-421 'Eagle' Liquid Methane Engine                 // MU-421
+    #LOC_CryoEngines_cryoengine-tyrannosaur-1_title   = CMR-37-4209 'Tyrannosaur' Liquid Methane Engine Cluster  // MR-420-9
+    #LOC_CryoEngines_cryoengine-vulture-1_title       = CME-37-4U 'Vulture' Liquid Methane Engine                // MU-4U
 
     // CryoTanks
     #LOC_CryoTanks_hydrogen-radial-125-1_title = YDR-01 Hydrogen Tank     // HR-1


### PR DESCRIPTION
Minor update for consistency with base CryoEngines. Hydrolox engines are now called "Liquid Hydrogen Engines" (formerly "Cryogenic Rocket Engines"); methalox engines are now called "Liquid Methane Engines" (were "Liquid Rocket Engines" in the prerelease)