### PR TITLE
Remote Tech

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/CPT_JX2Antenna.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_JX2Antenna.cfg
@@ -6,6 +6,6 @@
 @PART[jw1MDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C5+ Medium Deployable Antenna JW1 }  // JW1 Medium Deployable Antenna
 @PART[jx2LDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C6 Large Deployable Antenna JX2   }  // JX2 Large Deployable Antenna
 
-@PART[ju1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 JU1-12 Medium Deployable Antenna }
-@PART[jw1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 JW1-12 Medium Deployable Antenna }
-@PART[jx2LDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-m1 JX2-25 Large Deployable Antenna }
+@PART[ju1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 "JU1-12" Medium Deployable Antenna }
+@PART[jw1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 "JW1-12" Medium Deployable Antenna }
+@PART[jx2LDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-m1 "JX2-25" Large Deployable Antenna }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_JX2Antenna.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_JX2Antenna.cfg
@@ -1,0 +1,11 @@
+// JX2Antenna 2.0.5
+// 
+// Updated: William Minchin, 2022-01-17
+
+@PART[ju1MDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C5+ Medium Deployable Antenna JU1 }  // JU1 Medium Deployable Antenna
+@PART[jw1MDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C5+ Medium Deployable Antenna JW1 }  // JW1 Medium Deployable Antenna
+@PART[jx2LDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C6 Large Deployable Antenna JX2   }  // JX2 Large Deployable Antenna
+
+@PART[ju1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 JU1-12 Medium Deployable Antenna }
+@PART[jw1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 JW1-12 Medium Deployable Antenna }
+@PART[jx2LDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-m1 JX2-25 Large Deployable Antenna }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_JX2Antenna.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_JX2Antenna.cfg
@@ -2,10 +2,10 @@
 // 
 // Updated: William Minchin, 2022-01-17
 
-@PART[ju1MDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C5+ Medium Deployable Antenna JU1 }  // JU1 Medium Deployable Antenna
-@PART[jw1MDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C5+ Medium Deployable Antenna JW1 }  // JW1 Medium Deployable Antenna
-@PART[jx2LDA]:NEEDS[JX2Antenna,!RemoteTech]         { @title = C6 Large Deployable Antenna JX2   }  // JX2 Large Deployable Antenna
+@PART[ju1MDA]:NEEDS[JX2Antenna,!RemoteTech] { @title = C5+ Medium Deployable Antenna JU1 }  // JU1 Medium Deployable Antenna
+@PART[jw1MDA]:NEEDS[JX2Antenna,!RemoteTech] { @title = C5+ Medium Deployable Antenna JW1 }  // JW1 Medium Deployable Antenna
+@PART[jx2LDA]:NEEDS[JX2Antenna,!RemoteTech] { @title = C6 Large Deployable Antenna JX2   }  // JX2 Large Deployable Antenna
 
-@PART[ju1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 "JU1-12" Medium Deployable Antenna }
-@PART[jw1MDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-k300 "JW1-12" Medium Deployable Antenna }
-@PART[jx2LDA]:NEEDS[JX2Antenna,RemoteTech]          { @title = CD-m1 "JX2-25" Large Deployable Antenna }
+@PART[ju1MDA]:NEEDS[JX2Antenna,RemoteTech]  { @title = CD-k300 "JU1-12" Medium Deployable Antenna }
+@PART[jw1MDA]:NEEDS[JX2Antenna,RemoteTech]  { @title = CD-k300 "JW1-12" Medium Deployable Antenna }
+@PART[jx2LDA]:NEEDS[JX2Antenna,RemoteTech]  { @title = CD-m1 "JX2-25" Large Deployable Antenna    }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
@@ -1,6 +1,7 @@
+// Remote Tech 1.9.12
 // Adjust Antennta names to match Community Parts Title style when also using RemoteTech
 // Author: William Minchin
-// 2018-10-13
+// 2022-01-17
 
 // see also JX2 Antenna configuration
 
@@ -28,13 +29,17 @@
 }
 @PART[RelayAntenna100]:NEEDS[Squad,RemoteTech]:FINAL
 {
-    @title = CD-k100 Relay Antenna RA-100
+    @title = CD-k250 Relay Antenna RA-100
 }
 @PART[SurfAntenna]:NEEDS[Squad,RemoteTech]:FINAL
 {
     @title = CO-15 Communotron 16-S
 }
 @PART[HighGainAntenna5]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-020 High Gain Antenna HG-5
+}
+@PART[HighGainAntenna5_v2]:NEEDS[Squad,RemoteTech]:FINAL
 {
     @title = CD-020 High Gain Antenna HG-5
 }
@@ -87,5 +92,5 @@
 
 @PART[RTGigaDish1]:NEEDS[RemoteTech]:FINAL
 {
-    @title = CD-k800 Reflectron GX-128
+    @title = CD-k400 Reflectron GX-128
 }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
@@ -7,90 +7,25 @@
 
 
 // Squad Parts
-@PART[longAntenna]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CO-25 Communotron 16
-}
-@PART[commDish]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-k040 Communotron 88-88 
-}
-@PART[mediumDishAntenna]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-050 Communotron DTS-M1 
-}
-@PART[RelayAntenna5]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-200 Relay Antenna RA-2 
-}
-@PART[RelayAntenna50]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-k010 Relay Antenna RA-15
-}
-@PART[RelayAntenna100]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-k250 Relay Antenna RA-100
-}
-@PART[SurfAntenna]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CO-15 Communotron 16-S
-}
-@PART[HighGainAntenna5]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-020 High Gain Antenna HG-5
-}
-@PART[HighGainAntenna5_v2]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-020 High Gain Antenna HG-5
-}
-@PART[HighGainAntenna]:NEEDS[Squad,RemoteTech]:FINAL
-{
-    @title = CD-k025 Communotron HG-55 
-}
+@PART[longAntenna]:NEEDS[Squad,RemoteTech]          { @title = CO-25 Communotron 16             }
+@PART[commDish]:NEEDS[Squad,RemoteTech]             { @title = CD-k040 Communotron 88-88        }
+@PART[mediumDishAntenna]:NEEDS[Squad,RemoteTech]    { @title = CD-050 Communotron DTS-M1        }
+@PART[RelayAntenna5]:NEEDS[Squad,RemoteTech]        { @title = CD-200 Relay Antenna RA-2        }
+@PART[RelayAntenna50]:NEEDS[Squad,RemoteTech]       { @title = CD-k010 Relay Antenna RA-15      }
+@PART[RelayAntenna100]:NEEDS[Squad,RemoteTech]      { @title = CD-k250 Relay Antenna RA-100     }
+@PART[SurfAntenna]:NEEDS[Squad,RemoteTech]          { @title = CO-15 Communotron 16-S           }
+@PART[HighGainAntenna5]:NEEDS[Squad,RemoteTech]     { @title = CD-020 High Gain Antenna HG-5    }
+@PART[HighGainAntenna5_v2]:NEEDS[Squad,RemoteTech]  { @title = CD-020 High Gain Antenna HG-5    }
+@PART[HighGainAntenna]:NEEDS[Squad,RemoteTech]      { @title = CD-k025 Communotron HG-55        }
 
 
 // RemoteTech Parts
-@PART[RTShortAntenna1]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CO-05 Reflectron DP-10
-}
-
-@PART[RTLongAntenna3]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CO-30 CommTech EXP-VR-2T
-}
-
-@PART[RTLongAntenna2]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CO-50 Communotron 32
-}
-
-@PART[RTShortDish1]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CD-090 Reflectron SS-5
-}
-
-@PART[RTShortDish2]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CD-090 Reflectron KR-7
-}
-
-@PART[RTLongDish1]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CD-k060 Reflectron LL-5
-}
-
-@PART[RTLongDish2]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CD-k060 Reflectron KR-14
-}
-
-@PART[RTGigaDish2]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CD-k350 CommTech-1
-}
-
-@PART[RTGigaDish1]:NEEDS[RemoteTech]:FINAL
-{
-    @title = CD-k400 Reflectron GX-128
-}
+@PART[RTShortAntenna1]:NEEDS[RemoteTech]    { @title = CO-05 Reflectron DP-10       }
+@PART[RTLongAntenna3]:NEEDS[RemoteTech]     { @title = CO-30 CommTech EXP-VR-2T     }
+@PART[RTLongAntenna2]:NEEDS[RemoteTech]     { @title = CO-50 Communotron 32         }
+@PART[RTShortDish1]:NEEDS[RemoteTech]       { @title = CD-090 Reflectron SS-5       }
+@PART[RTShortDish2]:NEEDS[RemoteTech]       { @title = CD-090 Reflectron KR-7       }
+@PART[RTLongDish1]:NEEDS[RemoteTech]        { @title = CD-k060 Reflectron LL-5      }
+@PART[RTLongDish2]:NEEDS[RemoteTech]        { @title = CD-k060 Reflectron KR-14     }
+@PART[RTGigaDish2]:NEEDS[RemoteTech]        { @title = CD-k350 CommTech-1           }
+@PART[RTGigaDish1]:NEEDS[RemoteTech]        { @title = CD-k400 Reflectron GX-128    }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
@@ -2,6 +2,8 @@
 // Author: William Minchin
 // 2018-10-13
 
+// see also JX2 Antenna configuration
+
 
 // Squad Parts
 @PART[longAntenna]:NEEDS[Squad,RemoteTech]:FINAL
@@ -86,21 +88,4 @@
 @PART[RTGigaDish1]:NEEDS[RemoteTech]:FINAL
 {
     @title = CD-k800 Reflectron GX-128
-}
-
-
-// JX2 Antenna Parts
-@PART[ju1MDA]:NEEDS[JX2Antenna,RemoteTech]:FINAL
-{
-    @title = CD-k300 JU1-12 Medium Deployable Antenna
-}
-
-@PART[jw1MDA]:NEEDS[JX2Antenna,RemoteTech]:FINAL
-{
-    @title = CD-k300 JW1-12 Medium Deployable Antenna
-}
-
-@PART[jx2LDA]:NEEDS[JX2Antenna,RemoteTech]:FINAL
-{
-    @title = CD-m1 JX2-25 Large Deployable Antenna
 }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
@@ -1,0 +1,106 @@
+// Adjust Antennta names to match Community Parts Title style when also using RemoteTech
+// Author: William Minchin
+// 2018-10-13
+
+
+// Squad Parts
+@PART[longAntenna]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CO-25 Communotron 16
+}
+@PART[commDish]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-k040 Communotron 88-88 
+}
+@PART[mediumDishAntenna]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-050 Communotron DTS-M1 
+}
+@PART[RelayAntenna5]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-200 Relay Antenna RA-2 
+}
+@PART[RelayAntenna50]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-k010 Relay Antenna RA-15
+}
+@PART[RelayAntenna100]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-k100 Relay Antenna RA-100
+}
+@PART[SurfAntenna]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CO-15 Communotron 16-S
+}
+@PART[HighGainAntenna5]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-020 High Gain Antenna HG-5
+}
+@PART[HighGainAntenna]:NEEDS[Squad,RemoteTech]:FINAL
+{
+    @title = CD-k025 Communotron HG-55 
+}
+
+
+// RemoteTech Parts
+@PART[RTShortAntenna1]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CO-05 Reflectron DP-10
+}
+
+@PART[RTLongAntenna3]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CO-30 CommTech EXP-VR-2T
+}
+
+@PART[RTLongAntenna2]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CO-50 Communotron 32
+}
+
+@PART[RTShortDish1]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CD-090 Reflectron SS-5
+}
+
+@PART[RTShortDish2]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CD-090 Reflectron KR-7
+}
+
+@PART[RTLongDish1]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CD-k060 Reflectron LL-5
+}
+
+@PART[RTLongDish2]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CD-k060 Reflectron KR-14
+}
+
+@PART[RTGigaDish2]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CD-k350 CommTech-1
+}
+
+@PART[RTGigaDish1]:NEEDS[RemoteTech]:FINAL
+{
+    @title = CD-k800 Reflectron GX-128
+}
+
+
+// JX2 Antenna Parts
+@PART[ju1MDA]:NEEDS[JX2Antenna,RemoteTech]:FINAL
+{
+    @title = CD-k300 JU1-12 Medium Deployable Antenna
+}
+
+@PART[jw1MDA]:NEEDS[JX2Antenna,RemoteTech]:FINAL
+{
+    @title = CD-k300 JW1-12 Medium Deployable Antenna
+}
+
+@PART[jx2LDA]:NEEDS[JX2Antenna,RemoteTech]:FINAL
+{
+    @title = CD-m1 JX2-25 Large Deployable Antenna
+}

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_other-mods_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_other-mods_patch.cfg
@@ -4,7 +4,6 @@
 // RasterPropMonitor-Core (JSI\RasterPropMonitor) 0.31.4
 // PWBFuelBalancerRestored 0.2.1.6
 // DecouplerShroud 0.7.2
-// JX2Antenna 2.0.5
 // KerbalEngineerRedux 1.1.8.3
 // MSP3000 (MSP-3000 Material Science Pod) 1.1
 // MSP3000a (Material Science Pod Updated) 2.0.0
@@ -39,10 +38,6 @@
 @PART[PWBFuelBalancer]:NEEDS[PWBFuelBalancerRestored] { @title = Fuel Balancer (PWB)             }  // PWB Fuel Balancer
 
 @PART[ShroudedDecoupler]:NEEDS[DecouplerShroud]     { @title = Shrouded Decoupler                }  // ShroudedDecoupler
-
-@PART[ju1MDA]:NEEDS[JX2Antenna]                     { @title = C5+ Medium Deployable Antenna JU1 }  // JU1 Medium Deployable Antenna
-@PART[jw1MDA]:NEEDS[JX2Antenna]                     { @title = C5+ Medium Deployable Antenna JW1 }  // JW1 Medium Deployable Antenna
-@PART[jx2LDA]:NEEDS[JX2Antenna]                     { @title = C6 Large Deployable Antenna JX2   }  // JX2 Large Deployable Antenna
 
 // @PART[EngineerChip]:NEEDS[KerbalEngineer]        {}                                                // Kerbal Engineering System
 @PART[Engineer7500]:NEEDS[KerbalEngineer]           { @title = Kerbal Computer Flight Unit 'ER-7500' } // ER-7500 Computer Flight Unit


### PR DESCRIPTION
RemoteTech changes how the antennas work, most notably by splitting them into "omni-directional" (CO) and "directional" (CD). Also, antennas are rated on their actual transmission power rather than simply class.

This patch renames the stock antennas, the JX2 Antenna, and the included Remote Tech antennas.