### PR TITLE
+USI/Sounding Rockets

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
@@ -1,131 +1,50 @@
 // Sounding Rockets 1.4.0
 // Adjust USI parts names to match Community Parts Title style
 // Author: William Minchin
-// 2022-01-17
+// 2022-01-18
 
 
 // Pods
-@PART[SR_ProbeCore]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = RC Avionics Package   // Avionics Package
-}
-@PART[SR_InlineProbe]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = RC-03 Probe Core   // M-315 Probe Core
-}
-
+@PART[SR_ProbeCore]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = RC "Umbra Avionics" Package		}  // Avionics Package
+@PART[SR_InlineProbe]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = RC-03 "Umbra" Probe Core M-315	}  // M-315 Probe Core
 
 // Fuel Tanks
-@PART[SR_Tank_625_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = FL-S100 Fuel Tank  // SR-625A Fuel Tank
-}
-@PART[SR_Tank_35_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = FL-Q20 Fuel Tank  // SR-35A Fuel Tank
-}
-
+@PART[SR_Tank_625_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-S100 Fuel Tank				}  // SR-625A Fuel Tank
+@PART[SR_Tank_35_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-Q20 Fuel Tank					}  // SR-35A Fuel Tank
 
 // Engine
-@PART[SR_Aerospike]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = JT-0 Mini Aerospike Engine  // Mini Aerospike Engine
-}
-
+@PART[SR_Aerospike]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = JT-0 Mini Aerospike Engine		}  // Mini Aerospike Engine
 
 // Command and Control
-@PART[SR_Gyroscope]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = WR-03 Gryroscope  // Gyroscope (Small)
-}
-
+@PART[SR_Gyroscope]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = WR-03 Gryroscope					}  // Gyroscope (Small)
 
 // Structural
-@PART[SR_Adapter]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = Adapter 03-06-B   // Sounding Rocket Adapter
-}
-@PART[SR_LaunchStick]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = TT00 Launch Stick   // Launch Stick
-}
-
+@PART[SR_Adapter]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = Adapter 03-06-B					}  // Sounding Rocket Adapter
+@PART[SR_LaunchStick]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = TT00 Launch Stick				}  // Launch Stick
 
 // Coupling
-@PART[SR_Decoupler]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = TR-03 Stack Separator   // Mini stack separator (0.35m)
-}
-
+@PART[SR_Decoupler]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = TR-03 Stack Separator			}  // Mini stack separator (0.35m)
 
 // Payload
-@PART[SR_PayloadFairing_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = AE-FF00 SR Payload Fairing  // Payload Fairing (0.35m)
-}
-@PART[SR_PayloadFairing_625]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = AE-FF0 SR Payload Fairing  // Payload Fairing (0.625m)
-}
-
+@PART[SR_PayloadFairing_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]		{ @title = AE-FF00 SR Payload Fairing		}  // Payload Fairing (0.35m)
+@PART[SR_PayloadFairing_625]:NEEDS[UmbraSpaceIndustries/SoundingRockets]	{ @title = AE-FF0 SR Payload Fairing		}  // Payload Fairing (0.625m)
 
 // Aerodynamics
-@PART[SR_Wing_03]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = AV-B1 Sounding Rocket Fin   // Rocket fin (small)
-}
-@PART[SR_Wing_02]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = AV-B2 Sounding Rocket Fin   // Rocket fin (medium)
-}
-@PART[SR_Wing_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = AV-B3 Sounding Rocket Fin   // Rocket fin (large)
-}
+@PART[SR_Wing_03]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = AV-B1 Sounding Rocket Fin		}  // Rocket fin (small)
+@PART[SR_Wing_02]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = AV-B2 Sounding Rocket Fin		}  // Rocket fin (medium)
+@PART[SR_Wing_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = AV-B3 Sounding Rocket Fin		}  // Rocket fin (large)
 
-@PART[SR_Gridfin_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = GridFin Jr   // Small GridFin
-}
-@PART[SR_Gridfin_02]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = GridFin Mr   // Medium GridFin
-}
-@PART[SR_Gridfin_03]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = GridFin Sr   // Large GridFin
-}
-
+@PART[SR_Gridfin_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = GridFin Jr						}  // Small GridFin
+@PART[SR_Gridfin_02]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = GridFin Mr						}  // Medium GridFin
+@PART[SR_Gridfin_03]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = GridFin Sr						}  // Large GridFin
 
 // Electrical
-@PART[SR_Battery]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = Z-020 Battery Pack   // Mini Battery Pack
-}
-@PART[SR_Stack_Battery]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = Zs-03-100 Stackable Battery Pack   // Mini Battery Pack
-}
-
+@PART[SR_Battery]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = Z-020 Battery Pack				}  // Mini Battery Pack
+@PART[SR_Stack_Battery]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = Zs-03-100 Stackable Battery Pack	}  // Mini Battery Pack
 
 // Utility
-@PART[SR_Nosecone_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = Nk-03 Parachute + Nosecone   // Nosecone Parachute (0.35m)
-}
-@PART[SR_Nosecone_625]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = Nk-06 Parachute + Nosecone   // Nosecone Parachute (0.625m)
-}
-@PART[SR_PackChute_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = NPV-02 Pack Chute  // Pack Chute (Small)
-}
-@PART[SR_CargoChute]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = NPV-18 Heavy Cargo Chute  // Heavy Cargo Chute
-}
-@PART[SR_CargoDrogueChute]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
-{
-	@title = NPV-10D Cargo Drogue Chute  // Cargo Drogue Chute
-}
+@PART[SR_Nosecone_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = Nk-03 Parachute + Nosecone		}  // Nosecone Parachute (0.35m)
+@PART[SR_Nosecone_625]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = Nk-06 Parachute + Nosecone		}  // Nosecone Parachute (0.625m)
+@PART[SR_PackChute_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = NPV-02 Pack Chute				}  // Pack Chute (Small)
+@PART[SR_CargoChute]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = NPV-18 Heavy Cargo Chute			}  // Heavy Cargo Chute
+@PART[SR_CargoDrogueChute]:NEEDS[UmbraSpaceIndustries/SoundingRockets]		{ @title = NPV-10D Cargo Drogue Chute		}  // Cargo Drogue Chute

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
@@ -1,0 +1,131 @@
+// Sounding Rockets 1.4.0
+// Adjust USI parts names to match Community Parts Title style
+// Author: William Minchin
+// 2022-01-17
+
+
+// Pods
+@PART[SR_ProbeCore]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = RC Avionics Package   // Avionics Package
+}
+@PART[SR_InlineProbe]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = RC-03 Probe Core   // M-315 Probe Core
+}
+
+
+// Fuel Tanks
+@PART[SR_Tank_625_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = FL-S100 Fuel Tank  // SR-625A Fuel Tank
+}
+@PART[SR_Tank_35_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = FL-Q20 Fuel Tank  // SR-35A Fuel Tank
+}
+
+
+// Engine
+@PART[SR_Aerospike]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = JT-0 Mini Aerospike Engine  // Mini Aerospike Engine
+}
+
+
+// Command and Control
+@PART[SR_Gyroscope]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = WR-03 Gryroscope  // Gyroscope (Small)
+}
+
+
+// Structural
+@PART[SR_Adapter]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = Adapter 03-06-B   // Sounding Rocket Adapter
+}
+@PART[SR_LaunchStick]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = TT00 Launch Stick   // Launch Stick
+}
+
+
+// Coupling
+@PART[SR_Decoupler]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = TR-03 Stack Separator   // Mini stack separator (0.35m)
+}
+
+
+// Payload
+@PART[SR_PayloadFairing_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = AE-FF00 SR Payload Fairing  // Payload Fairing (0.35m)
+}
+@PART[SR_PayloadFairing_625]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = AE-FF0 SR Payload Fairing  // Payload Fairing (0.625m)
+}
+
+
+// Aerodynamics
+@PART[SR_Wing_03]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = AV-B1 Sounding Rocket Fin   // Rocket fin (small)
+}
+@PART[SR_Wing_02]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = AV-B2 Sounding Rocket Fin   // Rocket fin (medium)
+}
+@PART[SR_Wing_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = AV-B3 Sounding Rocket Fin   // Rocket fin (large)
+}
+
+@PART[SR_Gridfin_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = GridFin Jr   // Small GridFin
+}
+@PART[SR_Gridfin_02]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = GridFin Mr   // Medium GridFin
+}
+@PART[SR_Gridfin_03]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = GridFin Sr   // Large GridFin
+}
+
+
+// Electrical
+@PART[SR_Battery]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = Z-020 Battery Pack   // Mini Battery Pack
+}
+@PART[SR_Stack_Battery]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = Zs-03-100 Stackable Battery Pack   // Mini Battery Pack
+}
+
+
+// Utility
+@PART[SR_Nosecone_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = Nk-03 Parachute + Nosecone   // Nosecone Parachute (0.35m)
+}
+@PART[SR_Nosecone_625]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = Nk-06 Parachute + Nosecone   // Nosecone Parachute (0.625m)
+}
+@PART[SR_PackChute_35]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = NPV-02 Pack Chute  // Pack Chute (Small)
+}
+@PART[SR_CargoChute]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = NPV-18 Heavy Cargo Chute  // Heavy Cargo Chute
+}
+@PART[SR_CargoDrogueChute]:NEEDS[UmbraSpaceIndustries/SoundingRockets]
+{
+	@title = NPV-10D Cargo Drogue Chute  // Cargo Drogue Chute
+}


### PR DESCRIPTION
The only thing I wasn't sure was what to name the `SR_InlineProbe`. It is 0.3m in diameter, so "RC-03" seemed like the most logical (to match "RC-12"), but the -01, -02, and -03 are used (for the stock parts) to refer to the probe level rather than diameter...

Tested in-game with KSP 1.12.3 and Sounding Rockets 1.4.0.