### PR TITLE
+SSR Microsat

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RemoteTech.cfg
@@ -4,6 +4,7 @@
 // 2022-01-17
 
 // see also JX2 Antenna configuration
+// see also Squiggsy Space Research (MicroSat) configuration
 
 
 // Squad Parts

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
@@ -1,0 +1,36 @@
+// SSR Microsat Revived 0.1.4
+//
+// Author: William Minchin
+// 2022-01-18
+
+
+Localization
+{
+	en-us
+	{
+        #LOC_SSR_35decoupler_title          = TD-03 Squarified to Octagonal Adaptive Decoupler  // SSR Squarified to Octagonal Adaptive Decoupler
+        #LOC_SSR_625decoupler_title         = TD-06 Microsat Decoupler                          // 0.625m Decoupler
+        #LOC_SSR_625liquidFuel_title        = FL-S080 Fuel Tank                                 // 0.625m Fuel Tank
+        // #LOC_SSR_fairingSize0_title         = AE-FF0 SSR Fairing  // AE-FF0 Airstream Protective Shell (0.625m)
+        #LOC_SSR_FixedDish01_title          = C2 Smallified Dish Antenna                        // FD-01 Smallified Dish Antenna
+        #LOC_SSR_foldedDipole_title         = C0 Folded Dipole Antenna                          // Folded Dipole Antenna
+        #LOC_SSR_foldingDish01_title        = C1 DTS Antenna                                    // DTS-01 Antenna
+        #LOC_SSR_MICROBATSQUARE_title       = Z-060 SSR "MB-45" Square Battery                  // SSR MB-45 Battery
+        #LOC_SSR_microIon_title             = IX-SSR "Atom" MicroIonic Propulsion System        // SSR "Atom" MicroIonic Propulsion System
+        #LOC_SSR_microlqdfuel_title         = FL-Q14 MicroSat Liquid Fuel Tank                  // SSR MicroSat Liquid Fuel Tank
+        #LOC_SSR_micrortg_title             = U-NUK SSR MicroRTG                                // SSR MicroRTG
+        #LOC_SSR_MicroSat_title             = RC SSR MicroSat                                   // SSR MicroSat
+        // #LOC_SSR_microsatEngine_title       =  // SSR Microsat Liquid Fuel Engine
+        #LOC_SSR_MicroScanner_title         = M001 SSR MicroSat Survey Scanner                  // SSR MicroSat Survey Scanner
+        #LOC_SSR_microSolarUnshielded_title = OX 1x4 Photovoltaic Panels                        // SSR Micro Solar Array
+        #LOC_SSR_microXenon_title           = PB-03-20 Micro Xenon Container                    // SSR Micro Xenon Container
+        #LOC_SSR_radialXenonmicro_title     = PB-R002 Micro Radial Xenon Container              // SSR Micro Radial Xenon Container
+        #LOC_SSR_solidBoosterMini_title     = SRB-06-06 MicroSat Liquid Fuel Tank               // SRB625 "Thumper" MiniRocket
+        #LOC_SSR_upperStageEngine_title     = US-01 "Bambi" Liquid Fuel Engine                  // SSR US01 "Bambi" Liquid Fuel Engine
+    }
+}
+
+// rename for use with RemoteTech
+@PART[FixedDish01]:NEEDS[SquiggsySpaceResearch,RemoteTech]      { @title = CD-050 Smallified Dish Antenna FD-01 }
+@PART[foldedDipole]:NEEDS[SquiggsySpaceResearch,RemoteTech]     { @title = CO-03 Folded Dipole Antenna    }
+@PART[foldingDish01]:NEEDS[SquiggsySpaceResearch,RemoteTech]    { @title = CD-030 Antenna DTS-01            }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
@@ -25,12 +25,12 @@ Localization
         #LOC_SSR_microSolarUnshielded_title = OX 1x4 Photovoltaic Panels                        // SSR Micro Solar Array
         #LOC_SSR_microXenon_title           = PB-03-20 Micro Xenon Container                    // SSR Micro Xenon Container
         #LOC_SSR_radialXenonmicro_title     = PB-R002 Micro Radial Xenon Container              // SSR Micro Radial Xenon Container
-        #LOC_SSR_solidBoosterMini_title     = SRB-06-06 MicroSat Liquid Fuel Tank               // SRB625 "Thumper" MiniRocket
+        #LOC_SSR_solidBoosterMini_title     = SRB-06-06 "Thumper" MiniRocket                    // SRB625 "Thumper" MiniRocket
         #LOC_SSR_upperStageEngine_title     = US-01 "Bambi" Liquid Fuel Engine                  // SSR US01 "Bambi" Liquid Fuel Engine
     }
 }
 
 // rename for use with RemoteTech
 @PART[FixedDish01]:NEEDS[SquiggsySpaceResearch,RemoteTech]      { @title = CD-050 Smallified Dish Antenna FD-01 }
-@PART[foldedDipole]:NEEDS[SquiggsySpaceResearch,RemoteTech]     { @title = CO-03 Folded Dipole Antenna    }
-@PART[foldingDish01]:NEEDS[SquiggsySpaceResearch,RemoteTech]    { @title = CD-030 Antenna DTS-01            }
+@PART[foldedDipole]:NEEDS[SquiggsySpaceResearch,RemoteTech]     { @title = CO-03 Folded Dipole Antenna          }
+@PART[foldingDish01]:NEEDS[SquiggsySpaceResearch,RemoteTech]    { @title = CD-030 Antenna DTS-01                }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_other-mods_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_other-mods_patch.cfg
@@ -63,4 +63,4 @@
 @PART[size0_basicFin]:AFTER[ProbesBeforeCrew]       { @title = AV-B04 Tiny Basic Fin            }  // Tiny Basic Fin
 //@PART[RotorEngine_02]:AFTER[ProbesBeforeCrew]       {}  // R061 Turboshaft Engine
 
-@PART[indicatorLightSmall]:NEED[IndicatorLights]    { @title = I-BL1 Indicator Light            }  // BL-01 Indicator Light  
+@PART[indicatorLightSmall]:NEEDS[IndicatorLights]    { @title = I-BL1 Indicator Light            }  // BL-01 Indicator Light  


### PR DESCRIPTION
This adds the SSR Microsat, which is roughly 0.35m in diameter.

I've included the antenna renaming for when RemoteTech is installed.

Tested with KSP 1.12.3, SSR Microsat v0.1.4, and RemoteTech 1.9.12.