### PR TITLE
~Stock tanks

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/CPT_FarFutureTechnologies_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_FarFutureTechnologies_loc.cfg
@@ -37,26 +37,26 @@ Localization
 
 		
 		// Fusion Fuel Tanks
-		#LOC_FFT_fft-fueltank-fusion-25-1_title  = ST-25-412 Fusion Fuel Tank   // ST-412
-		#LOC_FFT_fft-fueltank-fusion-25-2_title  = ST-25-824 Fusion Fuel Tank   // ST-824
-		#LOC_FFT_fft-fueltank-fusion-375-1_title = ST-37-4L3 Fusion Fuel Tank   // ST-4L3
-		#LOC_FFT_fft-fueltank-fusion-375-2_title = ST-37-4L3R Fusion Fuel Tank  // ST-4L3R
+		#LOC_FFT_fft-fueltank-fusion-25-1_title  = ST-25-k01 Fusion Fuel Tank   // ST-412
+		#LOC_FFT_fft-fueltank-fusion-25-2_title  = ST-25-k06 Fusion Fuel Tank   // ST-824
+		#LOC_FFT_fft-fueltank-fusion-375-1_title = ST-37-k09 Fusion Fuel Tank   // ST-4L3
+		#LOC_FFT_fft-fueltank-fusion-375-2_title = ST-37-k36 Fusion Fuel Tank   // ST-4L3R
 
 		// Fission Fuel Tanks
-		#LOC_FFT_fft-fueltank-fission-radial-3_title = NTR-A Radial Fissonables Tank  // NTR-003
-		#LOC_FFT_fft-fueltank-fission-radial-2_title = NTR-B Radial Fissonables Tank  // NTR-002
-		#LOC_FFT_fft-fueltank-fission-radial-1_title = NTR-C Radial Fissonables Tank  // NTR-001
-		#LOC_FFT_fft-fueltank-fission-25-3_title     = NTS-25-A Fissonables Tank      // NTS-003
-		#LOC_FFT_fft-fueltank-fission-25-2_title     = NTS-25-B Fissonables Tank      // NTS-002
-		#LOC_FFT_fft-fueltank-fission-25-1_title     = NTS-25-C Fissonables Tank      // NTS-001
-		#LOC_FFT_fft-fueltank-fission-5-2_title      = NTS-50-A Fissonables Tank      // NTS-502
-		#LOC_FFT_fft-fueltank-fission-5-1_title      = NTS-50-B Fissonables Tank      // NTS-501
+		#LOC_FFT_fft-fueltank-fission-radial-3_title = NTS-R-k02 Radial Fissonables Tank  // NTR-003
+		#LOC_FFT_fft-fueltank-fission-radial-2_title = NTS-R-k04 Radial Fissonables Tank  // NTR-002
+		#LOC_FFT_fft-fueltank-fission-radial-1_title = NTS-R-k08 Radial Fissonables Tank  // NTR-001
+		#LOC_FFT_fft-fueltank-fission-25-3_title     = NTS-25-k08 Fissonables Tank      // NTS-003
+		#LOC_FFT_fft-fueltank-fission-25-2_title     = NTS-25-k16 Fissonables Tank      // NTS-002
+		#LOC_FFT_fft-fueltank-fission-25-1_title     = NTS-25-k32 Fissonables Tank      // NTS-001
+		#LOC_FFT_fft-fueltank-fission-5-2_title      = NTS-50-k042 Fissonables Tank      // NTS-502
+		#LOC_FFT_fft-fueltank-fission-5-1_title      = NTS-50-k084 Fissonables Tank      // NTS-501
 
 		// Antimatter Tanks
-		#LOC_FFT_fft-fueltank-antimatter-ring-75-1_title = ZA-R7NG-75 Antiproton Storage Ring        // A-R7NG
-		#LOC_FFT_fft-fueltank-antimatter-tank-5-1_title =  ZA-CY1-50 Antimatter Storage Container    // A-CY1-5
-		#LOC_FFT_fft-fueltank-antimatter-tank-25-1_title = ZA-CY1-25XL Antimatter Storage Container  // A-CY1-25XL
-		#LOC_FFT_fft-fueltank-antimatter-tank-25-2_title = ZA-CY1-25 Antimatter Storage Container    // A-CY1-25
+		#LOC_FFT_fft-fueltank-antimatter-ring-75-1_title = ZA-75-050 "R7NG" Antiproton Storage Ring        // A-R7NG
+		#LOC_FFT_fft-fueltank-antimatter-tank-5-1_title =  ZA-50-k096 "CY1-5" Antimatter Storage Container    // A-CY1-5
+		#LOC_FFT_fft-fueltank-antimatter-tank-25-1_title = ZA-25-k096 "CY1-25XL" Antimatter Storage Container  // A-CY1-25XL
+		#LOC_FFT_fft-fueltank-antimatter-tank-25-2_title = ZA-25-k048 "CY1-25" Antimatter Storage Container    // A-CY1-25
 
 		// Targets
 		// #LOC_FFT_fft-fueltank-targets-5-1_title = PW x4 Nuclear Pellet Storage Container

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_FuelTanksPlus_SpaceY_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_FuelTanksPlus_SpaceY_patch.cfg
@@ -4,10 +4,10 @@
 // 2021-02-28
 
 // mono
-@PART[TPmono0mL01875]:NEEDS[FuelTanksPlus]   {@title = FL-R06-10 RCS Fuel Tank    }  // FL-R05 RCS Fuel Tank
-@PART[TPmono1mL02850]:NEEDS[FuelTanksPlus]   {@title = FL-R12-060 RCS Fuel Tank   }  // FL-R13 RCS Fuel Tank
-@PART[TPmono2mL05000]:NEEDS[FuelTanksPlus]   {@title = FL-R25-0375 RCS Fuel Tank  }  // FL-R15 RCS Fuel Tank
-@PART[TPmono3mL05000]:NEEDS[FuelTanksPlus]   {@title = FL-R37-0840 RCS Fuel Tank  }  // FL-R375 RCS Fuel Tank
+@PART[TPmono0mL01875]:NEEDS[FuelTanksPlus]   {@title = OL-06-010 RCS Fuel Tank (FTP)  }  // FL-R05 RCS Fuel Tank
+@PART[TPmono1mL02850]:NEEDS[FuelTanksPlus]   {@title = OL-12-060 RCS Fuel Tank (FTP)  }  // FL-R13 RCS Fuel Tank
+@PART[TPmono2mL05000]:NEEDS[FuelTanksPlus]   {@title = OL-25-375 RCS Fuel Tank (FTP)  }  // FL-R15 RCS Fuel Tank
+@PART[TPmono3mL05000]:NEEDS[FuelTanksPlus]   {@title = OL-37-840 RCS Fuel Tank (FTP)  }  // FL-R375 RCS Fuel Tank
 
 
 @PART[TPdecoupler0m]:NEEDS[FuelTanksPlus]   {@title = TF-06 Fuel Decoupler (FTP) }  // FTP-DS0 Stack Decoupler (0.625m)
@@ -16,29 +16,29 @@
 @PART[TPdecoupler3m]:NEEDS[FuelTanksPlus]   {@title = TF-37 Fuel Decoupler (FTP) }  // FTP-DS3 Stack Decoupler (3.75m)
 
 // 0.6
-@PART[TPcone0m1]:NEEDS[FuelTanksPlus]       {@title = FL-06-40 Oscar-Cap Fuel Tank }  // <40 // Oscar-Cap 0.625m Fuel Tank
-@PART[TPtank0mL00175]:NEEDS[FuelTanksPlus]  {@title = FL-06-20 Oscar-A Fuel Tank   }  //     // Oscar-A 0.625m Fuel Tank
-@PART[TPtank0mL00700]:NEEDS[FuelTanksPlus]  {@title = FL-06-56 Oscar-C Fuel Tank   }  // 80  // Oscar-C 0.625m Fuel Tank
-@PART[TPtank0mL01350]:NEEDS[FuelTanksPlus]  {@title = FL-06-80 Oscar-D Fuel Tank   }  // 160 // Oscar-D 0.625m Fuel Tank
-@PART[TPtank0mL01875]:NEEDS[FuelTanksPlus]  {@title = FL-06-A0 Oscar-E Fuel Tank   }  // 220 // Probodobodyne 0.625m FTP-100 Fuel Tank
+@PART[TPcone0m1]:NEEDS[FuelTanksPlus]       {@title = FS-06-040 Oscar-Cap Fuel Tank (FTP) }  // <40 // Oscar-Cap 0.625m Fuel Tank
+@PART[TPtank0mL00175]:NEEDS[FuelTanksPlus]  {@title = FL-06-020 Oscar-A Fuel Tank (FTP)   }  //     // Oscar-A 0.625m Fuel Tank
+@PART[TPtank0mL00700]:NEEDS[FuelTanksPlus]  {@title = FL-06-056 Oscar-C Fuel Tank (FTP)   }  // 80  // Oscar-C 0.625m Fuel Tank
+@PART[TPtank0mL01350]:NEEDS[FuelTanksPlus]  {@title = FL-06-080 Oscar-D Fuel Tank (FTP)   }  // 160 // Oscar-D 0.625m Fuel Tank
+@PART[TPtank0mL01875]:NEEDS[FuelTanksPlus]  {@title = FL-06-100 Oscar-E Fuel Tank (FTP)   }  // 220 // Probodobodyne 0.625m FTP-100 Fuel Tank
 
 // 1.25
 @PART[TPcone1m1]:NEEDS[FuelTanksPlus]             {@title = FS-12-128 Nose Tank (FTP)              }  // FL-T128C 1.25m Nose Tank
 @PART[TPcone1m2]:NEEDS[FuelTanksPlus]             {@title = FS-12-128 Slanted Nose Tank (FTP)      }  // FL-T128CS 1.25m Slanted Nose Tank
 @PART[TPdome1m1]:NEEDS[FuelTanksPlus]             {@title = FS-12-100 Bottom Dome (FTP)            }  // FL-T100-FTP Bottom Dome
 @PART[TPtank1m0mA]:NEEDS[FuelTanksPlus]           {@title = FS-12-100 Adapter 06-12 (FTP)          }  // FL-A100-FTP Adapter Tank
-@PART[TPtank1mL00313]:NEEDS[FuelTanksPlus]        {@title = FL-12-050 Fuel Tank (FTP)               }  // FL-T50-FTP Fuel Tank
-@PART[TPtank1mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-12-1200 Fuel Tank (FTP)               }  // FL-T1200-FTP Fuel Tank
+@PART[TPtank1mL00313]:NEEDS[FuelTanksPlus]        {@title = FL-12-050 Fuel Tank (FTP)              }  // FL-T50-FTP Fuel Tank
+@PART[TPtank1mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-12-k1 Fuel Tank (FTP)               }  // FL-T1200-FTP Fuel Tank
 
 // FX-32 Rockomax Fuel Tank
 // FW-08 Rockomax Adapter 12-25
 @PART[TPcone2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-16 Rockomax Nose Tank (FTP)           }  // Rockomax FTP-16 2.5m Nose Tank
 @PART[TPdome2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-08 Rockomax Bottom Dome (FTP)         }  // Rockomax FTP-8 2.5m Bottom Dome
 @PART[TPtank2m1mA]:NEEDS[FuelTanksPlus]           {@title = FV-12-25-08 Rockomax Adapter Tank (FTP)  }  // Rockomax X200-08-FTP Adapter Tank
-@PART[TPtank2mL00469]:NEEDS[FuelTanksPlus]        {@title = FL-25-04 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-4-FTP 2.5m Fuel Tank
-@PART[TPtank2mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-25-48 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-48-FTP 2.5m Fuel Tank
-@PART[TPtank2mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-25-96 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-96-FTP 2.5m Fuel Tank
-@PART[TPtank2mL15000]:NEEDS[FuelTanksPlus]        {@title = FL-25-C8 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-128-FTP 2.5m Fuel Tank
+@PART[TPtank2mL00469]:NEEDS[FuelTanksPlus]        {@title = FL-25-400 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-4-FTP 2.5m Fuel Tank
+@PART[TPtank2mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-25-k05 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-48-FTP 2.5m Fuel Tank
+@PART[TPtank2mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-25-k10 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-96-FTP 2.5m Fuel Tank
+@PART[TPtank2mL15000]:NEEDS[FuelTanksPlus]        {@title = FL-25-k13 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-128-FTP 2.5m Fuel Tank
 
 // Kerbodyne S3-072 Fuel Tank
 // Kerbodyne S3-S4 Adapter Tank
@@ -46,10 +46,10 @@
 @PART[TPdome3m]:NEEDS[FuelTanksPlus]              {@title = FS-37-012 Kerbodyne Dome Tank (FTP)         }  // Kerbodyne S3-1200-FTP Dome Tank
 @PART[TPtank3m2mA]:NEEDS[FuelTanksPlus]           {@title = FV-25-37-050 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-5076-FTP Adapter Tank
 @PART[TPtank3m2mA2]:NEEDS[FuelTanksPlus]          {@title = FV-25-37-030 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-3045-FTP Adapter Tank
-@PART[TPtank3mL00938]:NEEDS[FuelTanksPlus]        {@title = FL-37-018 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-10800-FTP Tank
-@PART[TPtank3mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-37-108 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-21600-FTP Tank
-@PART[TPtank3mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-37-216 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
-@PART[TPtank3mL15000]:NEEDS[FuelTanksPlus]        {@title = FL-37-288 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
+@PART[TPtank3mL00938]:NEEDS[FuelTanksPlus]        {@title = FL-37-k02 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-10800-FTP Tank
+@PART[TPtank3mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-37-k10 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-21600-FTP Tank
+@PART[TPtank3mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-37-k22 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
+@PART[TPtank3mL15000]:NEEDS[FuelTanksPlus]        {@title = FL-37-k29 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
 
 @PART[TPtank1mL00938-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-200 L-Nuc LF Tank (FTP)       }  // FL-T200N Propellant Tank
 @PART[TPtank1mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-400 L-Nuc LF Tank (FTP)       }  // FL-T400N Propellant Tank
@@ -72,22 +72,22 @@
 @PART[SYtank3mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-37-027 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F03C 3.75m Fuel Tank Nose Cone
 @PART[SYtank5m3mAdapter]:NEEDS[SpaceY-Lifters]   {@title = FV-37-50-095 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F9A5-3 5m Fuel Tank Adapter
 @PART[SYtank5mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-50-054 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F05C 5m Fuel Tank Nose Cone
-@PART[SYtank5mL01875]:NEEDS[SpaceY-Lifters]      {@title = FL-50-063 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F06 5m Fuel Tank
-@PART[SYtank5mL0375]:NEEDS[SpaceY-Lifters]       {@title = FL-50-126 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F12 5m Fuel Tank
-@PART[SYtank5mL0750]:NEEDS[SpaceY-Lifters]       {@title = FL-50-252 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F26 5m Fuel Tank
-@PART[SYtank5mL1125]:NEEDS[SpaceY-Lifters]       {@title = FL-50-378 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F38 5m Fuel Tank
-@PART[SYtank5mL1500]:NEEDS[SpaceY-Lifters]       {@title = FL-50-504 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F51 5m Fuel Tank
-@PART[SYtank7mCone1]:NEEDS[SpaceY-Expanded]      {@title = FL-75-160 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY BFT07C 7.5m Fuel Tank Nose Cone
+@PART[SYtank5mL01875]:NEEDS[SpaceY-Lifters]      {@title = FL-50-k06 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F06 5m Fuel Tank
+@PART[SYtank5mL0375]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k13 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F12 5m Fuel Tank
+@PART[SYtank5mL0750]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k25 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F26 5m Fuel Tank
+@PART[SYtank5mL1125]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k38 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F38 5m Fuel Tank
+@PART[SYtank5mL1500]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k50 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F51 5m Fuel Tank
+@PART[SYtank7mCone1]:NEEDS[SpaceY-Expanded]      {@title = FS-75-k016 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY BFT07C 7.5m Fuel Tank Nose Cone
 @PART[SYtank7m5mAdapter]:NEEDS[SpaceY-Expanded]  {@title = FV-50-75-288 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F28A7-5 7.5m Fuel Tank Adapter
 @PART[SYtank7m5mAdapter2]:NEEDS[SpaceY-Expanded] {@title = FV-50-75-216 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F21A7-5 7.5m Fuel Tank Adapter
 @PART[SYtank10m7mAdapter]:NEEDS[SpaceY-Expanded] {@title = FV-75-A0-383 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY BFR-TA38 Fuel Tank Adapter
-@PART[SYtank7mL03750]:NEEDS[SpaceY-Expanded]     {@title = FL-75-0288 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT28 7.5m Fuel Tank
-@PART[SYtank7mL07500]:NEEDS[SpaceY-Expanded]     {@title = FL-75-0576 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT57 7.5m Fuel Tank
-@PART[SYtank7mL15000]:NEEDS[SpaceY-Expanded]     {@title = FL-75-1152 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT115 7.5m Fuel Tank
-@PART[SYtank10mL03750]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-0504 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T50 Fuel Tank
-@PART[SYtank10mL07500]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-1008 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T100 Fuel Tank
-@PART[SYtank10mL15000]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-2016 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T200 Fuel Tank
-@PART[SYtank10mL22500]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-3024 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T300 Fuel Tank
+@PART[SYtank7mL03750]:NEEDS[SpaceY-Expanded]     {@title = FL-75-k029 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT28 7.5m Fuel Tank
+@PART[SYtank7mL07500]:NEEDS[SpaceY-Expanded]     {@title = FL-75-k058 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT57 7.5m Fuel Tank
+@PART[SYtank7mL15000]:NEEDS[SpaceY-Expanded]     {@title = FL-75-k115 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT115 7.5m Fuel Tank
+@PART[SYtank10mL03750]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-k050 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T50 Fuel Tank
+@PART[SYtank10mL07500]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-k101 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T100 Fuel Tank
+@PART[SYtank10mL15000]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-k202 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T200 Fuel Tank
+@PART[SYtank10mL22500]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-k302 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T300 Fuel Tank
 
 
 @PART[SYejectatron]:NEEDS[SpaceY-Lifters]  {@title = SRB-R Sepratron II SpaceY "Ejectatron" }  // SpaceY S01 "Ejectatron" Solid Rocket Booster

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_FuelTanksPlus_SpaceY_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_FuelTanksPlus_SpaceY_patch.cfg
@@ -16,48 +16,48 @@
 @PART[TPdecoupler3m]:NEEDS[FuelTanksPlus]   {@title = TF-37 Fuel Decoupler (FTP) }  // FTP-DS3 Stack Decoupler (3.75m)
 
 // 0.6
-@PART[TPcone0m1]:NEEDS[FuelTanksPlus]       {@title = FL-S40 Oscar-Cap Fuel Tank }  // <40 // Oscar-Cap 0.625m Fuel Tank
-@PART[TPtank0mL00175]:NEEDS[FuelTanksPlus]  {@title = FL-S20 Oscar-A Fuel Tank   }  //     // Oscar-A 0.625m Fuel Tank
-@PART[TPtank0mL00700]:NEEDS[FuelTanksPlus]  {@title = FL-S56 Oscar-C Fuel Tank   }  // 80  // Oscar-C 0.625m Fuel Tank
-@PART[TPtank0mL01350]:NEEDS[FuelTanksPlus]  {@title = FL-S80 Oscar-D Fuel Tank   }  // 160 // Oscar-D 0.625m Fuel Tank
-@PART[TPtank0mL01875]:NEEDS[FuelTanksPlus]  {@title = FL-SA0 Oscar-E Fuel Tank   }  // 220 // Probodobodyne 0.625m FTP-100 Fuel Tank
+@PART[TPcone0m1]:NEEDS[FuelTanksPlus]       {@title = FL-06-40 Oscar-Cap Fuel Tank }  // <40 // Oscar-Cap 0.625m Fuel Tank
+@PART[TPtank0mL00175]:NEEDS[FuelTanksPlus]  {@title = FL-06-20 Oscar-A Fuel Tank   }  //     // Oscar-A 0.625m Fuel Tank
+@PART[TPtank0mL00700]:NEEDS[FuelTanksPlus]  {@title = FL-06-56 Oscar-C Fuel Tank   }  // 80  // Oscar-C 0.625m Fuel Tank
+@PART[TPtank0mL01350]:NEEDS[FuelTanksPlus]  {@title = FL-06-80 Oscar-D Fuel Tank   }  // 160 // Oscar-D 0.625m Fuel Tank
+@PART[TPtank0mL01875]:NEEDS[FuelTanksPlus]  {@title = FL-06-A0 Oscar-E Fuel Tank   }  // 220 // Probodobodyne 0.625m FTP-100 Fuel Tank
 
 // 1.25
-@PART[TPcone1m1]:NEEDS[FuelTanksPlus]             {@title = FL-SW128 Nose Tank (FTP)              }  // FL-T128C 1.25m Nose Tank
-@PART[TPcone1m2]:NEEDS[FuelTanksPlus]             {@title = FL-SW128 Slanted Nose Tank (FTP)      }  // FL-T128CS 1.25m Slanted Nose Tank
-@PART[TPdome1m1]:NEEDS[FuelTanksPlus]             {@title = FL-SW100 Bottom Dome (FTP)            }  // FL-T100-FTP Bottom Dome
-@PART[TPtank1m0mA]:NEEDS[FuelTanksPlus]           {@title = FL-SV100 Adapter 06-12 (FTP)          }  // FL-A100-FTP Adapter Tank
-@PART[TPtank1mL00313]:NEEDS[FuelTanksPlus]        {@title = FL-T050 Fuel Tank (FTP)               }  // FL-T50-FTP Fuel Tank
-@PART[TPtank1mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-TC00 Fuel Tank (FTP)               }  // FL-T1200-FTP Fuel Tank
+@PART[TPcone1m1]:NEEDS[FuelTanksPlus]             {@title = FS-12-128 Nose Tank (FTP)              }  // FL-T128C 1.25m Nose Tank
+@PART[TPcone1m2]:NEEDS[FuelTanksPlus]             {@title = FS-12-128 Slanted Nose Tank (FTP)      }  // FL-T128CS 1.25m Slanted Nose Tank
+@PART[TPdome1m1]:NEEDS[FuelTanksPlus]             {@title = FS-12-100 Bottom Dome (FTP)            }  // FL-T100-FTP Bottom Dome
+@PART[TPtank1m0mA]:NEEDS[FuelTanksPlus]           {@title = FS-12-100 Adapter 06-12 (FTP)          }  // FL-A100-FTP Adapter Tank
+@PART[TPtank1mL00313]:NEEDS[FuelTanksPlus]        {@title = FL-12-050 Fuel Tank (FTP)               }  // FL-T50-FTP Fuel Tank
+@PART[TPtank1mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-12-1200 Fuel Tank (FTP)               }  // FL-T1200-FTP Fuel Tank
 
 // FX-32 Rockomax Fuel Tank
 // FW-08 Rockomax Adapter 12-25
-@PART[TPcone2m]:NEEDS[FuelTanksPlus]              {@title = FW-16 Rockomax Nose Tank (FTP)           }  // Rockomax FTP-16 2.5m Nose Tank
-@PART[TPdome2m]:NEEDS[FuelTanksPlus]              {@title = FW-08 Rockomax Bottom Dome (FTP)         }  // Rockomax FTP-8 2.5m Bottom Dome
-@PART[TPtank2m1mA]:NEEDS[FuelTanksPlus]           {@title = FV-08 Rockomax Adapter Tank 12-25 (FTP)  }  // Rockomax X200-08-FTP Adapter Tank
-@PART[TPtank2mL00469]:NEEDS[FuelTanksPlus]        {@title = FX-04 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-4-FTP 2.5m Fuel Tank
-@PART[TPtank2mL05625]:NEEDS[FuelTanksPlus]        {@title = FX-48 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-48-FTP 2.5m Fuel Tank
-@PART[TPtank2mL11250]:NEEDS[FuelTanksPlus]        {@title = FX-96 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-96-FTP 2.5m Fuel Tank
-@PART[TPtank2mL15000]:NEEDS[FuelTanksPlus]        {@title = FX-C8 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-128-FTP 2.5m Fuel Tank
+@PART[TPcone2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-16 Rockomax Nose Tank (FTP)           }  // Rockomax FTP-16 2.5m Nose Tank
+@PART[TPdome2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-08 Rockomax Bottom Dome (FTP)         }  // Rockomax FTP-8 2.5m Bottom Dome
+@PART[TPtank2m1mA]:NEEDS[FuelTanksPlus]           {@title = FV-12-25-08 Rockomax Adapter Tank (FTP)  }  // Rockomax X200-08-FTP Adapter Tank
+@PART[TPtank2mL00469]:NEEDS[FuelTanksPlus]        {@title = FL-25-04 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-4-FTP 2.5m Fuel Tank
+@PART[TPtank2mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-25-48 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-48-FTP 2.5m Fuel Tank
+@PART[TPtank2mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-25-96 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-96-FTP 2.5m Fuel Tank
+@PART[TPtank2mL15000]:NEEDS[FuelTanksPlus]        {@title = FL-25-C8 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-128-FTP 2.5m Fuel Tank
 
 // Kerbodyne S3-072 Fuel Tank
 // Kerbodyne S3-S4 Adapter Tank
-@PART[TPcone3m]:NEEDS[FuelTanksPlus]              {@title = Kerbodyne S3 024 Nose Tank (FTP)         }  // Kerbodyne S3-2400-FTP Nose Tank
-@PART[TPdome3m]:NEEDS[FuelTanksPlus]              {@title = Kerbodyne S3 012 Dome Tank (FTP)         }  // Kerbodyne S3-1200-FTP Dome Tank
-@PART[TPtank3m2mA]:NEEDS[FuelTanksPlus]           {@title = Kerbodyne S2-S3-050 Adapter Tank (FTP)   }  // Kerbodyne S3-5076-FTP Adapter Tank
-@PART[TPtank3m2mA2]:NEEDS[FuelTanksPlus]          {@title = Kerbodyne S2-S3-030 Adapter Tank (FTP)   }  // Kerbodyne S3-3045-FTP Adapter Tank
-@PART[TPtank3mL00938]:NEEDS[FuelTanksPlus]        {@title = Kerbodyne S3-018 Tank (FTP)              }  // Kerbodyne S3-10800-FTP Tank
-@PART[TPtank3mL05625]:NEEDS[FuelTanksPlus]        {@title = Kerbodyne S3-108 Tank (FTP)              }  // Kerbodyne S3-21600-FTP Tank
-@PART[TPtank3mL11250]:NEEDS[FuelTanksPlus]        {@title = Kerbodyne S3-216 Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
-@PART[TPtank3mL15000]:NEEDS[FuelTanksPlus]        {@title = Kerbodyne S3-288 Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
+@PART[TPcone3m]:NEEDS[FuelTanksPlus]              {@title = FS-37-024 Kerbodyne Nose Tank (FTP)         }  // Kerbodyne S3-2400-FTP Nose Tank
+@PART[TPdome3m]:NEEDS[FuelTanksPlus]              {@title = FS-37-012 Kerbodyne Dome Tank (FTP)         }  // Kerbodyne S3-1200-FTP Dome Tank
+@PART[TPtank3m2mA]:NEEDS[FuelTanksPlus]           {@title = FV-25-37-050 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-5076-FTP Adapter Tank
+@PART[TPtank3m2mA2]:NEEDS[FuelTanksPlus]          {@title = FV-25-37-030 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-3045-FTP Adapter Tank
+@PART[TPtank3mL00938]:NEEDS[FuelTanksPlus]        {@title = FL-37-018 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-10800-FTP Tank
+@PART[TPtank3mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-37-108 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-21600-FTP Tank
+@PART[TPtank3mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-37-216 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
+@PART[TPtank3mL15000]:NEEDS[FuelTanksPlus]        {@title = FL-37-288 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
 
-@PART[TPtank1mL00938-Nuke]:NEEDS[FuelTanksPlus]   {@title = L-Nuc-S1-200 LF Tank (FTP)       }  // FL-T200N Propellant Tank
-@PART[TPtank1mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = L-Nuc-S1-400 LF Tank (FTP)       }  // FL-T400N Propellant Tank
-@PART[TPtank1mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = L-Nuc-S1-800 LF Tank (FTP)       }  // FL-T800N Propellant Tank
-@PART[TPtank2mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = L-Nuc-S2-16 LF Tank (FTP)        }  // Rockomax Nuc-16 Propellant Tank
-@PART[TPtank2mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = L-Nuc-S2-32 LF Tank (FTP)        }  // Rockomax Nuc-32 Propellant Tank
-@PART[TPtank2mL07500-Nuke]:NEEDS[FuelTanksPlus]   {@title = L-Nuc-S2-64 LF Tank (FTP)        }  // Rockomax Nuc-64 Propellant Tank
-@PART[TPtank3mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = L-Nuc-S3-72 LF Tank (FTP)        }  // Kerbodyne S3-7200-FTP Propellant Tank
+@PART[TPtank1mL00938-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-200 L-Nuc LF Tank (FTP)       }  // FL-T200N Propellant Tank
+@PART[TPtank1mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-400 L-Nuc LF Tank (FTP)       }  // FL-T400N Propellant Tank
+@PART[TPtank1mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-800 L-Nuc LF Tank (FTP)       }  // FL-T800N Propellant Tank
+@PART[TPtank2mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-25-16 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-16 Propellant Tank
+@PART[TPtank2mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-25-32 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-32 Propellant Tank
+@PART[TPtank2mL07500-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-25-64 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-64 Propellant Tank
+@PART[TPtank3mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-37-72 L-Nuc LF Tank (FTP)        }  // Kerbodyne S3-7200-FTP Propellant Tank
 
 
 //=========
@@ -68,29 +68,29 @@
 @PART[SYprobe5m]:NEEDS[SpaceY-Lifters]       {@title = RC-50 Stack Guidance System (SpaceY)           }  // SpaceY Stack Guidance System, 5m
 @PART[SYprobe7m]:NEEDS[SpaceY-Expanded]      {@title = RC-75 Stack Guidance System (SpaceY)           }  // SpaceY Stack Guidance System, 7.5m
 
-@PART[SYtank3mCone]:NEEDS[SpaceY-Lifters]        {@title = Kerbodyne S3 018 Nose Cone (SpaceY)        }  // SpaceY F02C 3.75m Fuel Tank Nose Cone
-@PART[SYtank3mCone2]:NEEDS[SpaceY-Lifters]       {@title = Kerbodyne S3 027 Nose Cone (SpaceY)        }  // SpaceY F03C 3.75m Fuel Tank Nose Cone
-@PART[SYtank5m3mAdapter]:NEEDS[SpaceY-Lifters]   {@title = Kerbodyne S3-S4-095 Adapter Tank (SpaceY)  }  // SpaceY F9A5-3 5m Fuel Tank Adapter
-@PART[SYtank5mCone2]:NEEDS[SpaceY-Lifters]       {@title = Kerbodyne S4 054 Nose Cone (SpaceY)        }  // SpaceY F05C 5m Fuel Tank Nose Cone
-@PART[SYtank5mL01875]:NEEDS[SpaceY-Lifters]      {@title = Kerbodyne S4-063 Fuel Tank (SpaceY)        }  // SpaceY F06 5m Fuel Tank
-@PART[SYtank5mL0375]:NEEDS[SpaceY-Lifters]       {@title = Kerbodyne S4-126 Fuel Tank (SpaceY)        }  // SpaceY F12 5m Fuel Tank
-@PART[SYtank5mL0750]:NEEDS[SpaceY-Lifters]       {@title = Kerbodyne S4-252 Fuel Tank (SpaceY)        }  // SpaceY F26 5m Fuel Tank
-@PART[SYtank5mL1125]:NEEDS[SpaceY-Lifters]       {@title = Kerbodyne S4-378 Fuel Tank (SpaceY)        }  // SpaceY F38 5m Fuel Tank
-@PART[SYtank5mL1500]:NEEDS[SpaceY-Lifters]       {@title = Kerbodyne S4-504 Fuel Tank (SpaceY)        }  // SpaceY F51 5m Fuel Tank
-@PART[SYtank7mCone1]:NEEDS[SpaceY-Expanded]      {@title = Kerbodyne S5 160 Nose Cone (SpaceY)        }  // SpaceY BFT07C 7.5m Fuel Tank Nose Cone
-@PART[SYtank7m5mAdapter]:NEEDS[SpaceY-Expanded]  {@title = Kerbodyne S4-S5-288 Adapter Tank (SpaceY)  }  // SpaceY F28A7-5 7.5m Fuel Tank Adapter
-@PART[SYtank7m5mAdapter2]:NEEDS[SpaceY-Expanded] {@title = Kerbodyne S4-S5-216 Adapter Tank (SpaceY)  }  // SpaceY F21A7-5 7.5m Fuel Tank Adapter
-@PART[SYtank10m7mAdapter]:NEEDS[SpaceY-Expanded] {@title = Kerbodyne S5-S6-383 Adapter Tank (SpaceY)  }  // SpaceY BFR-TA38 Fuel Tank Adapter
-@PART[SYtank7mL03750]:NEEDS[SpaceY-Expanded]     {@title = Kerbodyne S5-0288 Fuel Tank (SpaceY)       }  // SpaceY BFT28 7.5m Fuel Tank
-@PART[SYtank7mL07500]:NEEDS[SpaceY-Expanded]     {@title = Kerbodyne S5-0576 Fuel Tank (SpaceY)       }  // SpaceY BFT57 7.5m Fuel Tank
-@PART[SYtank7mL15000]:NEEDS[SpaceY-Expanded]     {@title = Kerbodyne S5-1152 Fuel Tank (SpaceY)       }  // SpaceY BFT115 7.5m Fuel Tank
-@PART[SYtank10mL03750]:NEEDS[SpaceY-Expanded]    {@title = Kerbodyne S6-0504 Fuel Tank (SpaceY)       }  // SpaceY BFR-T50 Fuel Tank
-@PART[SYtank10mL07500]:NEEDS[SpaceY-Expanded]    {@title = Kerbodyne S6-1008 Fuel Tank (SpaceY)       }  // SpaceY BFR-T100 Fuel Tank
-@PART[SYtank10mL15000]:NEEDS[SpaceY-Expanded]    {@title = Kerbodyne S6-2016 Fuel Tank (SpaceY)       }  // SpaceY BFR-T200 Fuel Tank
-@PART[SYtank10mL22500]:NEEDS[SpaceY-Expanded]    {@title = Kerbodyne S6-3024 Fuel Tank (SpaceY)       }  // SpaceY BFR-T300 Fuel Tank
+@PART[SYtank3mCone]:NEEDS[SpaceY-Lifters]        {@title = FS-37-018 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F02C 3.75m Fuel Tank Nose Cone
+@PART[SYtank3mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-37-027 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F03C 3.75m Fuel Tank Nose Cone
+@PART[SYtank5m3mAdapter]:NEEDS[SpaceY-Lifters]   {@title = FV-37-50-095 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F9A5-3 5m Fuel Tank Adapter
+@PART[SYtank5mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-50-054 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F05C 5m Fuel Tank Nose Cone
+@PART[SYtank5mL01875]:NEEDS[SpaceY-Lifters]      {@title = FL-50-063 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F06 5m Fuel Tank
+@PART[SYtank5mL0375]:NEEDS[SpaceY-Lifters]       {@title = FL-50-126 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F12 5m Fuel Tank
+@PART[SYtank5mL0750]:NEEDS[SpaceY-Lifters]       {@title = FL-50-252 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F26 5m Fuel Tank
+@PART[SYtank5mL1125]:NEEDS[SpaceY-Lifters]       {@title = FL-50-378 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F38 5m Fuel Tank
+@PART[SYtank5mL1500]:NEEDS[SpaceY-Lifters]       {@title = FL-50-504 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F51 5m Fuel Tank
+@PART[SYtank7mCone1]:NEEDS[SpaceY-Expanded]      {@title = FL-75-160 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY BFT07C 7.5m Fuel Tank Nose Cone
+@PART[SYtank7m5mAdapter]:NEEDS[SpaceY-Expanded]  {@title = FV-50-75-288 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F28A7-5 7.5m Fuel Tank Adapter
+@PART[SYtank7m5mAdapter2]:NEEDS[SpaceY-Expanded] {@title = FV-50-75-216 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F21A7-5 7.5m Fuel Tank Adapter
+@PART[SYtank10m7mAdapter]:NEEDS[SpaceY-Expanded] {@title = FV-75-A0-383 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY BFR-TA38 Fuel Tank Adapter
+@PART[SYtank7mL03750]:NEEDS[SpaceY-Expanded]     {@title = FL-75-0288 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT28 7.5m Fuel Tank
+@PART[SYtank7mL07500]:NEEDS[SpaceY-Expanded]     {@title = FL-75-0576 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT57 7.5m Fuel Tank
+@PART[SYtank7mL15000]:NEEDS[SpaceY-Expanded]     {@title = FL-75-1152 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT115 7.5m Fuel Tank
+@PART[SYtank10mL03750]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-0504 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T50 Fuel Tank
+@PART[SYtank10mL07500]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-1008 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T100 Fuel Tank
+@PART[SYtank10mL15000]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-2016 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T200 Fuel Tank
+@PART[SYtank10mL22500]:NEEDS[SpaceY-Expanded]    {@title = FL-A0-3024 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFR-T300 Fuel Tank
 
 
-@PART[SYejectatron]:NEEDS[SpaceY-Lifters]  {@title = SRB Sepratron II SpaceY "Ejectatron"   }  // SpaceY S01 "Ejectatron" Solid Rocket Booster
+@PART[SYejectatron]:NEEDS[SpaceY-Lifters]  {@title = SRB-R Sepratron II SpaceY "Ejectatron" }  // SpaceY S01 "Ejectatron" Solid Rocket Booster
 @PART[SYSRB_0625L5]:NEEDS[SpaceY-Lifters]  {@title = SRB-06-15 SpaceY Light (5m)            }  // SpaceY 05S SRB (0.625m x 5m)
 @PART[SYSRB_0625L6R]:NEEDS[SpaceY-Lifters] {@title = SRB-06-16A SpaceY Light (6m)           }  // SpaceY 06R Radial SRB (0.625m x 6m)
 @PART[SYSRB_0625L9]:NEEDS[SpaceY-Lifters]  {@title = SRB-06-30 SpaceY Light (9m)            }  // SpaceY 09S SRB (0.625m x 9m)

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_FuelTanksPlus_SpaceY_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_FuelTanksPlus_SpaceY_patch.cfg
@@ -25,16 +25,16 @@
 // 1.25
 @PART[TPcone1m1]:NEEDS[FuelTanksPlus]             {@title = FS-12-128 Nose Tank (FTP)              }  // FL-T128C 1.25m Nose Tank
 @PART[TPcone1m2]:NEEDS[FuelTanksPlus]             {@title = FS-12-128 Slanted Nose Tank (FTP)      }  // FL-T128CS 1.25m Slanted Nose Tank
-@PART[TPdome1m1]:NEEDS[FuelTanksPlus]             {@title = FS-12-100 Bottom Dome (FTP)            }  // FL-T100-FTP Bottom Dome
-@PART[TPtank1m0mA]:NEEDS[FuelTanksPlus]           {@title = FS-12-100 Adapter 06-12 (FTP)          }  // FL-A100-FTP Adapter Tank
+@PART[TPdome1m1]:NEEDS[FuelTanksPlus]             {@title = FS-12-100 Bottom Dome Fuel Tank (FTP)  }  // FL-T100-FTP Bottom Dome
+@PART[TPtank1m0mA]:NEEDS[FuelTanksPlus]           {@title = FV-12-18-100 Adapter Fuel Tank (FTP)   }  // FL-A100-FTP Adapter Tank
 @PART[TPtank1mL00313]:NEEDS[FuelTanksPlus]        {@title = FL-12-050 Fuel Tank (FTP)              }  // FL-T50-FTP Fuel Tank
 @PART[TPtank1mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-12-k1 Fuel Tank (FTP)               }  // FL-T1200-FTP Fuel Tank
 
 // FX-32 Rockomax Fuel Tank
 // FW-08 Rockomax Adapter 12-25
-@PART[TPcone2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-16 Rockomax Nose Tank (FTP)           }  // Rockomax FTP-16 2.5m Nose Tank
-@PART[TPdome2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-08 Rockomax Bottom Dome (FTP)         }  // Rockomax FTP-8 2.5m Bottom Dome
-@PART[TPtank2m1mA]:NEEDS[FuelTanksPlus]           {@title = FV-12-25-08 Rockomax Adapter Tank (FTP)  }  // Rockomax X200-08-FTP Adapter Tank
+@PART[TPcone2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-k2 Rockomax Nose Tank (FTP)            }  // Rockomax FTP-16 2.5m Nose Tank
+@PART[TPdome2m]:NEEDS[FuelTanksPlus]              {@title = FS-25-800 Rockomax Bottom Dome (FTP)         }  // Rockomax FTP-8 2.5m Bottom Dome
+@PART[TPtank2m1mA]:NEEDS[FuelTanksPlus]           {@title = FV-12-25-800 Rockomax Adapter Tank (FTP)     }  // Rockomax X200-08-FTP Adapter Tank
 @PART[TPtank2mL00469]:NEEDS[FuelTanksPlus]        {@title = FL-25-400 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-4-FTP 2.5m Fuel Tank
 @PART[TPtank2mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-25-k05 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-48-FTP 2.5m Fuel Tank
 @PART[TPtank2mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-25-k10 Rockomax Fuel Tank (FTP)           }  // Rockomax X200-96-FTP 2.5m Fuel Tank
@@ -42,22 +42,22 @@
 
 // Kerbodyne S3-072 Fuel Tank
 // Kerbodyne S3-S4 Adapter Tank
-@PART[TPcone3m]:NEEDS[FuelTanksPlus]              {@title = FS-37-024 Kerbodyne Nose Tank (FTP)         }  // Kerbodyne S3-2400-FTP Nose Tank
-@PART[TPdome3m]:NEEDS[FuelTanksPlus]              {@title = FS-37-012 Kerbodyne Dome Tank (FTP)         }  // Kerbodyne S3-1200-FTP Dome Tank
-@PART[TPtank3m2mA]:NEEDS[FuelTanksPlus]           {@title = FV-25-37-050 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-5076-FTP Adapter Tank
-@PART[TPtank3m2mA2]:NEEDS[FuelTanksPlus]          {@title = FV-25-37-030 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-3045-FTP Adapter Tank
+@PART[TPcone3m]:NEEDS[FuelTanksPlus]              {@title = FS-37-k02 Kerbodyne Nose Tank (FTP)         }  // Kerbodyne S3-2400-FTP Nose Tank
+@PART[TPdome3m]:NEEDS[FuelTanksPlus]              {@title = FS-37-k01 Kerbodyne Dome Tank (FTP)         }  // Kerbodyne S3-1200-FTP Dome Tank
+@PART[TPtank3m2mA]:NEEDS[FuelTanksPlus]           {@title = FV-25-37-k05 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-5076-FTP Adapter Tank
+@PART[TPtank3m2mA2]:NEEDS[FuelTanksPlus]          {@title = FV-25-37-k03 Kerbodyne Adapter Tank (FTP)   }  // Kerbodyne S3-3045-FTP Adapter Tank
 @PART[TPtank3mL00938]:NEEDS[FuelTanksPlus]        {@title = FL-37-k02 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-10800-FTP Tank
-@PART[TPtank3mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-37-k10 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-21600-FTP Tank
+@PART[TPtank3mL05625]:NEEDS[FuelTanksPlus]        {@title = FL-37-k11 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-21600-FTP Tank
 @PART[TPtank3mL11250]:NEEDS[FuelTanksPlus]        {@title = FL-37-k22 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
 @PART[TPtank3mL15000]:NEEDS[FuelTanksPlus]        {@title = FL-37-k29 Kerbodyne Tank (FTP)              }  // Kerbodyne S3-28800-FTP Tank
 
-@PART[TPtank1mL00938-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-200 L-Nuc LF Tank (FTP)       }  // FL-T200N Propellant Tank
-@PART[TPtank1mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-400 L-Nuc LF Tank (FTP)       }  // FL-T400N Propellant Tank
-@PART[TPtank1mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-12-800 L-Nuc LF Tank (FTP)       }  // FL-T800N Propellant Tank
-@PART[TPtank2mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-25-16 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-16 Propellant Tank
-@PART[TPtank2mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-25-32 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-32 Propellant Tank
-@PART[TPtank2mL07500-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-25-64 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-64 Propellant Tank
-@PART[TPtank3mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = FN-37-72 L-Nuc LF Tank (FTP)        }  // Kerbodyne S3-7200-FTP Propellant Tank
+@PART[TPtank1mL00938-Nuke]:NEEDS[FuelTanksPlus]   {@title = NL-12-200 L-Nuc LF Tank (FTP)       }  // FL-T200N Propellant Tank
+@PART[TPtank1mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = NL-12-400 L-Nuc LF Tank (FTP)       }  // FL-T400N Propellant Tank
+@PART[TPtank1mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = NL-12-800 L-Nuc LF Tank (FTP)       }  // FL-T800N Propellant Tank
+@PART[TPtank2mL01875-Nuke]:NEEDS[FuelTanksPlus]   {@title = NL-25-k02 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-16 Propellant Tank
+@PART[TPtank2mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = NL-25-k03 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-32 Propellant Tank
+@PART[TPtank2mL07500-Nuke]:NEEDS[FuelTanksPlus]   {@title = NL-25-k06 L-Nuc LF Tank (FTP)        }  // Rockomax Nuc-64 Propellant Tank
+@PART[TPtank3mL03750-Nuke]:NEEDS[FuelTanksPlus]   {@title = NL-37-k07 L-Nuc LF Tank (FTP)        }  // Kerbodyne S3-7200-FTP Propellant Tank
 
 
 //=========
@@ -69,18 +69,18 @@
 @PART[SYprobe7m]:NEEDS[SpaceY-Expanded]      {@title = RC-75 Stack Guidance System (SpaceY)           }  // SpaceY Stack Guidance System, 7.5m
 
 @PART[SYtank3mCone]:NEEDS[SpaceY-Lifters]        {@title = FS-37-018 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F02C 3.75m Fuel Tank Nose Cone
-@PART[SYtank3mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-37-027 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F03C 3.75m Fuel Tank Nose Cone
-@PART[SYtank5m3mAdapter]:NEEDS[SpaceY-Lifters]   {@title = FV-37-50-095 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F9A5-3 5m Fuel Tank Adapter
-@PART[SYtank5mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-50-054 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F05C 5m Fuel Tank Nose Cone
+@PART[SYtank3mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-37-k03 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F03C 3.75m Fuel Tank Nose Cone
+@PART[SYtank5m3mAdapter]:NEEDS[SpaceY-Lifters]   {@title = FV-37-50-k09 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F9A5-3 5m Fuel Tank Adapter
+@PART[SYtank5mCone2]:NEEDS[SpaceY-Lifters]       {@title = FS-50-k05 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY F05C 5m Fuel Tank Nose Cone
 @PART[SYtank5mL01875]:NEEDS[SpaceY-Lifters]      {@title = FL-50-k06 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F06 5m Fuel Tank
 @PART[SYtank5mL0375]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k13 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F12 5m Fuel Tank
 @PART[SYtank5mL0750]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k25 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F26 5m Fuel Tank
 @PART[SYtank5mL1125]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k38 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F38 5m Fuel Tank
 @PART[SYtank5mL1500]:NEEDS[SpaceY-Lifters]       {@title = FL-50-k50 Kerbodyne Fuel Tank (SpaceY)        }  // SpaceY F51 5m Fuel Tank
 @PART[SYtank7mCone1]:NEEDS[SpaceY-Expanded]      {@title = FS-75-k016 Kerbodyne Nose Cone (SpaceY)        }  // SpaceY BFT07C 7.5m Fuel Tank Nose Cone
-@PART[SYtank7m5mAdapter]:NEEDS[SpaceY-Expanded]  {@title = FV-50-75-288 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F28A7-5 7.5m Fuel Tank Adapter
-@PART[SYtank7m5mAdapter2]:NEEDS[SpaceY-Expanded] {@title = FV-50-75-216 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F21A7-5 7.5m Fuel Tank Adapter
-@PART[SYtank10m7mAdapter]:NEEDS[SpaceY-Expanded] {@title = FV-75-A0-383 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY BFR-TA38 Fuel Tank Adapter
+@PART[SYtank7m5mAdapter]:NEEDS[SpaceY-Expanded]  {@title = FV-50-75-k29 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F28A7-5 7.5m Fuel Tank Adapter
+@PART[SYtank7m5mAdapter2]:NEEDS[SpaceY-Expanded] {@title = FV-50-75-k21 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY F21A7-5 7.5m Fuel Tank Adapter
+@PART[SYtank10m7mAdapter]:NEEDS[SpaceY-Expanded] {@title = FV-75-A0-k38 Kerbodyne Adapter Tank (SpaceY)  }  // SpaceY BFR-TA38 Fuel Tank Adapter
 @PART[SYtank7mL03750]:NEEDS[SpaceY-Expanded]     {@title = FL-75-k029 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT28 7.5m Fuel Tank
 @PART[SYtank7mL07500]:NEEDS[SpaceY-Expanded]     {@title = FL-75-k058 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT57 7.5m Fuel Tank
 @PART[SYtank7mL15000]:NEEDS[SpaceY-Expanded]     {@title = FL-75-k115 Kerbodyne Fuel Tank (SpaceY)       }  // SpaceY BFT115 7.5m Fuel Tank

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_KerbalAtomics_CryoEngines_CryoTanks_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_KerbalAtomics_CryoEngines_CryoTanks_loc.cfg
@@ -41,21 +41,21 @@ Localization
 		#LOC_CryoEngines_cryoengine-vulture-1_title       = CME-37-4U 'Vulture' Liquid Methane Engine                // MU-4U
 
 		// CryoTanks
-		#LOC_CryoTanks_hydrogen-radial-125-1_title = YDR-01 Hydrogen Tank     // HR-1
-		#LOC_CryoTanks_hydrogen-radial-25-1_title  = YDR-18 Hydrogen Tank     // HR-18
-		#LOC_CryoTanks_hydrogen-radial-375-1_title = YDR-64 Hydrogen Tank     // HR-64
-		#LOC_CryoTanks_hydrogen-125-2_title        = YD12-4 Hydrogen Tank     // H125-4
-		#LOC_CryoTanks_hydrogen-125-1_title        = YD12-8 Hydrogen Tank     // H125-8
-		#LOC_CryoTanks_hydrogen-25-3_title         = YD25-16 Hydrogen Tank    // H250-16
-		#LOC_CryoTanks_hydrogen-25-2_title         = YD25-32 Hydrogen Tank    // H250-32
-		#LOC_CryoTanks_hydrogen-25-1_title         = YD25-64 Hydrogen Tank    // H250-64
-		#LOC_CryoTanks_hydrogen-375-3_title        = YD37-036 Hydrogen Tank   // H375-36
-		#LOC_CryoTanks_hydrogen-375-2_title        = YD37-072 Hydrogen Tank   // H375-72
-		#LOC_CryoTanks_hydrogen-375-1_title        = YD37-144 Hydrogen Tank   // H375-144
-		#LOC_CryoTanks_hydrogen-5-3_title          = YD50-144 Hydrogen Tank   // H500-144
-		#LOC_CryoTanks_hydrogen-5-2_title          = YD50-288 Hydrogen Tank   // H500-288
-		#LOC_CryoTanks_hydrogen-5-1_title          = YD50-576 Hydrogen Tank   // H500-576
-		#LOC_CryoTanks_hydrogen-10-1_title         = YDA0-1152 Hydrogen Tank  // H1000-1152
+		#LOC_CryoTanks_hydrogen-radial-125-1_title = YD-R-160 Hydrogen Tank     // HR-1
+		#LOC_CryoTanks_hydrogen-radial-25-1_title  = YD-R-k02 Hydrogen Tank     // HR-18
+		#LOC_CryoTanks_hydrogen-radial-375-1_title = YD-R-k06 Hydrogen Tank     // HR-64
+		#LOC_CryoTanks_hydrogen-125-2_title        = YD-12-400 Hydrogen Tank     // H125-4
+		#LOC_CryoTanks_hydrogen-125-1_title        = YD-12-800 Hydrogen Tank     // H125-8
+		#LOC_CryoTanks_hydrogen-25-3_title         = YD-25-k02 Hydrogen Tank    // H250-16
+		#LOC_CryoTanks_hydrogen-25-2_title         = YD-25-k03 Hydrogen Tank    // H250-32
+		#LOC_CryoTanks_hydrogen-25-1_title         = YD-25-k06 Hydrogen Tank    // H250-64
+		#LOC_CryoTanks_hydrogen-375-3_title        = YD-37-k04 Hydrogen Tank   // H375-36
+		#LOC_CryoTanks_hydrogen-375-2_title        = YD-37-k07 Hydrogen Tank   // H375-72
+		#LOC_CryoTanks_hydrogen-375-1_title        = YD-37-k14 Hydrogen Tank   // H375-144
+		#LOC_CryoTanks_hydrogen-5-3_title          = YD-50-k14 Hydrogen Tank   // H500-144
+		#LOC_CryoTanks_hydrogen-5-2_title          = YD-50-k29 Hydrogen Tank   // H500-288
+		#LOC_CryoTanks_hydrogen-5-1_title          = YD-50-k58 Hydrogen Tank   // H500-576
+		#LOC_CryoTanks_hydrogen-10-1_title         = YD-37-k115 Expanded Hydrogen Tank  // H1000-1152
 
 
 		// CryoEngines legacy (pre-1.0)

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_KerbalAtomics_CryoEngines_CryoTanks_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_KerbalAtomics_CryoEngines_CryoTanks_loc.cfg
@@ -17,7 +17,7 @@ Localization
 		#LOC_KerbalAtomics_ntr-gc-25-2_title   = LV-NGX 'Emancipator' Atomic Rocket Motor            // NV-GX
 		#LOC_KerbalAtomics_ntr-sc-375-1_title  = LV-NGZ 'Scylla' Atomic Aerospike Rocket             // NV-DC
 
-	 // CryoEngines
+	    // CryoEngines
 		#LOC_CryoEngines_cryoengine-stromboli-1_title = CHR-06-10A 'Stromboli' Liquid Hydrogen Engine        // CR-10A
 		#LOC_CryoEngines_cryoengine-vesuvius-1_title  = CHR-12-2 'Vesuvius' Liquid Hydrogen Engine           // CR-2
 		#LOC_CryoEngines_cryoengine-hecate-1_title    = CHE-12-10 'Hecate' Liquid Hydrogen Engine            // CE-10

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_KerbalReusabilityExpansion_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_KerbalReusabilityExpansion_patch.cfg
@@ -3,7 +3,7 @@
 
 
 // Fuel Tank
-@PART[DragonFuelTank]:NEEDS[KerbalReusabilityExpansion]         {@title = FX-04 Dragon Fuel Tank         }  // Dragon Fuel Tank
+@PART[DragonFuelTank]:NEEDS[KerbalReusabilityExpansion]         {@title = FL-25-400 "Dragon" Fuel Tank         }  // Dragon Fuel Tank
 
 // Engines
 // @PART[SmallCapsuleEngine]:NEEDS[KerbalReusabilityExpansion]    {@title = SuperDraco Engine            }  // SuperDraco Engine

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_Kerbonov_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_Kerbonov_patch.cfg
@@ -13,8 +13,8 @@
 @PART[50lDropTank]:NEEDS[Kerbonov]            {@title = M-050 Drop Tank                                 }  //  50 Litre Drop Tank
 @PART[150lDropTank]:NEEDS[Kerbonov]           {@title = M-150 Drop Tank                                 }  //  150 Litre Drop Tank
 @PART[400lDropTank]:NEEDS[Kerbonov]           {@title = M-400 Drop Tank                                 }  //  400 Litre Drop Tank
-@PART[fuelTank_extralong]:NEEDS[Kerbonov]     {@title = FL-12-k2 Fuel Tank (Kerbonov                    }  //  FL-T1600 Fuel Tank
-@PART[fuelTank4-0]:NEEDS[Kerbonov]            {@title = FX-04 Rockomax Fuel Tank                        }  //  Rockomax X200-4 Fuel Tank
+@PART[fuelTank_extralong]:NEEDS[Kerbonov]     {@title = FL-12-k2 Fuel Tank (Kerbonov)                    }  //  FL-T1600 Fuel Tank
+@PART[fuelTank4-0]:NEEDS[Kerbonov]            {@title = FL-25-400 Rockomax Fuel Tank (Kerbonov)                        }  //  Rockomax X200-4 Fuel Tank
 
 @PART[ProbeRCSBlock]:NEEDS[Kerbonov]          {@title = RV-030 Self-Contained Probe RCS                 }  //  Self-Contained Probe RCS
 @PART[ModifiedProbeRCSBlock]:NEEDS[Kerbonov]  {@title = RV-030 Self-Contained Probe RCS (45°)           }  //  Modified Self-Contained Probe RCS

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_Kerbonov_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_Kerbonov_patch.cfg
@@ -13,7 +13,7 @@
 @PART[50lDropTank]:NEEDS[Kerbonov]            {@title = M-050 Drop Tank                                 }  //  50 Litre Drop Tank
 @PART[150lDropTank]:NEEDS[Kerbonov]           {@title = M-150 Drop Tank                                 }  //  150 Litre Drop Tank
 @PART[400lDropTank]:NEEDS[Kerbonov]           {@title = M-400 Drop Tank                                 }  //  400 Litre Drop Tank
-@PART[fuelTank_extralong]:NEEDS[Kerbonov]     {@title = FL-TG00 Fuel Tank                               }  //  FL-T1600 Fuel Tank
+@PART[fuelTank_extralong]:NEEDS[Kerbonov]     {@title = FL-12-k2 Fuel Tank (Kerbonov                    }  //  FL-T1600 Fuel Tank
 @PART[fuelTank4-0]:NEEDS[Kerbonov]            {@title = FX-04 Rockomax Fuel Tank                        }  //  Rockomax X200-4 Fuel Tank
 
 @PART[ProbeRCSBlock]:NEEDS[Kerbonov]          {@title = RV-030 Self-Contained Probe RCS                 }  //  Self-Contained Probe RCS

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_KiwiTechTree_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_KiwiTechTree_patch.cfg
@@ -20,7 +20,7 @@
 @PART[kiwi-monoprop-1875-2]:LAST[KiwiTechTree]        {@title = FL-R18-422 RCS Fuel Tank            }  // FL-R-BX422 Monopropellant Tank
 @PART[kiwi-monoprop-1875-3]:LAST[KiwiTechTree]        {@title = FL-R18-211 RCS Fuel Tank            }  // FL-R-BX211 Monopropellant Tank
 
-@PART[kiwi-adapter-1875-125]:LAST[KiwiTechTree]       {@title = FL-TW374 Adapter 12-18 (Long)       }  // Kerbodyne ADTP-1.5-2
+@PART[kiwi-adapter-1875-125]:LAST[KiwiTechTree]       {@title = FL-12-18-B-374 Adapter Fuel Tank (Kiwi)       }  // Kerbodyne ADTP-1.5-2
 
 @PART[kiwi-radiator-surface-1875-1]:LAST[KiwiTechTree] {@title = XF-18-75 "Yank" High Temperature Heat Radiator  }  // YF-50 "Yank" High Temperature Heat Radiator
 @PART[kiwi-radiator-surface-1875-1]:LAST[KiwiTechTree] { @description ^= :YF:XF:           }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_KiwiTechTree_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_KiwiTechTree_patch.cfg
@@ -8,19 +8,19 @@
 @PART[kiwi-reactionwheel-375-1]:LAST[KiwiTechTree]    {@title = WR-37 Reaction Wheel Assembly (Very Large)      }  // Very Large Reaction Wheel Assembly
 @PART[kiwi-reactionwheel-5-1]:LAST[KiwiTechTree]      {@title = WR-50 Reaction Wheel Assembly (Very Very Large) }  // Very Very Large Reaction Wheel Assembly
 
-@PART[kiwi-hydrogen-1875-1]:LAST[KiwiTechTree]        {@title = YD18-18 Hydrogen Tank               }  // H1875-18 Hydrogen Tank
-@PART[kiwi-hydrogen-1875-2]:LAST[KiwiTechTree]        {@title = YD18-09 Hydrogen Tank               }  // H1875-9 Hydrogen Tank
-@PART[kiwi-hydrogen-1875-3]:LAST[KiwiTechTree]        {@title = YD18-05 Hydrogen Tank               }  // H1875-4.5 Hydrogen Tank
-@PART[kiwi-hydrogen-radial-1875-1]:LAST[KiwiTechTree] {@title = YDR-08 Hydrogen Tank                }  // HR-8 Hydrogen Tank
+@PART[kiwi-hydrogen-1875-1]:LAST[KiwiTechTree]        {@title = YD-18-k02 Hydrogen Tank (Kiwi)        }  // H1875-18 Hydrogen Tank
+@PART[kiwi-hydrogen-1875-2]:LAST[KiwiTechTree]        {@title = YD-18-900 Hydrogen Tank (Kiwi)        }  // H1875-9 Hydrogen Tank
+@PART[kiwi-hydrogen-1875-3]:LAST[KiwiTechTree]        {@title = YD-18-450 Hydrogen Tank (Kiwi)        }  // H1875-4.5 Hydrogen Tank
+@PART[kiwi-hydrogen-radial-1875-1]:LAST[KiwiTechTree] {@title = YD-R-742 Hydrogen Tank (Kiwi)         }  // HR-8 Hydrogen Tank
 
-@PART[kiwi-monoprop-0625-1]:LAST[KiwiTechTree]        {@title = FL-R06-94 RCS Fuel Tank             }  // FL-R-0A211 Monopropellant Tank
-@PART[kiwi-monoprop-0625-2]:LAST[KiwiTechTree]        {@title = FL-R06-47 RCS Fuel Tank             }  // FL-R-0A106 Monopropellant Tank
-@PART[kiwi-monoprop-0625-3]:LAST[KiwiTechTree]        {@title = FL-R06-23 RCS Fuel Tank             }  // FL-R-0A53 Monopropellant Tank
-@PART[kiwi-monoprop-1875-1]:LAST[KiwiTechTree]        {@title = FL-R18-844 RCS Fuel Tank            }  // FL-R-BX844 Monopropellant Tank
-@PART[kiwi-monoprop-1875-2]:LAST[KiwiTechTree]        {@title = FL-R18-422 RCS Fuel Tank            }  // FL-R-BX422 Monopropellant Tank
-@PART[kiwi-monoprop-1875-3]:LAST[KiwiTechTree]        {@title = FL-R18-211 RCS Fuel Tank            }  // FL-R-BX211 Monopropellant Tank
+@PART[kiwi-monoprop-0625-1]:LAST[KiwiTechTree]        {@title = OL-06-094 RCS Fuel Tank (Kiwi)       }  // FL-R-0A211 Monopropellant Tank
+@PART[kiwi-monoprop-0625-2]:LAST[KiwiTechTree]        {@title = OL-06-047 RCS Fuel Tank (Kiwi)       }  // FL-R-0A106 Monopropellant Tank
+@PART[kiwi-monoprop-0625-3]:LAST[KiwiTechTree]        {@title = OL-06-023 RCS Fuel Tank (Kiwi)       }  // FL-R-0A53 Monopropellant Tank
+@PART[kiwi-monoprop-1875-1]:LAST[KiwiTechTree]        {@title = OL-18-844 RCS Fuel Tank (Kiwi)      }  // FL-R-BX844 Monopropellant Tank
+@PART[kiwi-monoprop-1875-2]:LAST[KiwiTechTree]        {@title = OL-18-422 RCS Fuel Tank (Kiwi)      }  // FL-R-BX422 Monopropellant Tank
+@PART[kiwi-monoprop-1875-3]:LAST[KiwiTechTree]        {@title = OL-18-211 RCS Fuel Tank (Kiwi)      }  // FL-R-BX211 Monopropellant Tank
 
-@PART[kiwi-adapter-1875-125]:LAST[KiwiTechTree]       {@title = FL-12-18-B-374 Adapter Fuel Tank (Kiwi)       }  // Kerbodyne ADTP-1.5-2
+@PART[kiwi-adapter-1875-125]:LAST[KiwiTechTree]       {@title = FV-12-18-B-374 Adapter Fuel Tank (Kiwi)       }  // Kerbodyne ADTP-1.5-2
 
 @PART[kiwi-radiator-surface-1875-1]:LAST[KiwiTechTree] {@title = XF-18-75 "Yank" High Temperature Heat Radiator  }  // YF-50 "Yank" High Temperature Heat Radiator
 @PART[kiwi-radiator-surface-1875-1]:LAST[KiwiTechTree] { @description ^= :YF:XF:           }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_MiningExpansion_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_MiningExpansion_loc.cfg
@@ -17,10 +17,10 @@ Localization
 	{
 		#LOC_SMX_manufacturer_title = Coreworks Extractions Consortium (SME) // Coreworks Extractions Consortium
 
-		#LOC_SMX_Size3OreTank_name = UH-37-4500 Holding Tank (Huge)   // Huge Holding Tank
-		#LOC_SMX_Mk3OreTank_name   = UH-Mk3-4000 Holding Tank         // Mk3 Holding Tank
+		#LOC_SMX_Size3OreTank_name = UH-37-k05 Holding Tank (Huge)   // Huge Holding Tank
+		#LOC_SMX_Mk3OreTank_name   = UH-Mk3-k04 Holding Tank         // Mk3 Holding Tank
 		#LOC_SMX_MK2OreTank_Name   = UH-Mk2-550 Holding Tank          // Mk2 Holding Tank
-		#LOC_SMX_Size0reTank_Name  = UH-06-50 Holding Tank (Tiny)     // Tiny Holding Tank
+		#LOC_SMX_Size0reTank_Name  = UH-06-050 Holding Tank (Tiny)    // Tiny Holding Tank
 
 		#LOC_SMX_Driver0_title     = EMMD-08 "Onager" Mass Driver     // EMMD-8 "Onager" Mass Driver
 		#LOC_SMX_Driver1_title     = EMMD-32 "Trebuchet" Mass Driver  // EMMD-32 "Trebuchet" Mass Driver

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_MissingHistory_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_MissingHistory_loc.cfg
@@ -2,7 +2,7 @@
 // 2021-02-28
 
 
-@PART[adapterSmallMiniTall]:AFTER[MissingHistory]:HAS[@RESOURCE[LiquidFuel]]  { @title = FL-SW060 Adapter 06-12  }    // Adapter 06-12-B
+@PART[adapterSmallMiniTall]:AFTER[MissingHistory]:HAS[@RESOURCE[LiquidFuel]]  { @title = FW-06-12-060 Adapter Fuel Tank (Missing History)  }    // Adapter 06-12-B
 
 Localization
 {

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_MissingHistory_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_MissingHistory_loc.cfg
@@ -2,7 +2,7 @@
 // 2021-02-28
 
 
-@PART[adapterSmallMiniTall]:AFTER[MissingHistory]:HAS[@RESOURCE[LiquidFuel]]  { @title = FW-06-12-060 Adapter Fuel Tank (Missing History)  }    // Adapter 06-12-B
+@PART[adapterSmallMiniTall]:AFTER[MissingHistory]:HAS[@RESOURCE[LiquidFuel]]  { @title = FV-06-12-060 Adapter Fuel Tank (Missing History)  }    // Adapter 06-12-B
 
 Localization
 {
@@ -11,10 +11,10 @@ Localization
 		#MissingHistory_probeStack_1p5_title = RC-18 Remote Guidance Unit  // RC-001M Remote Guidance Unit
 		#MissingHistory_probeStack_1p5_desc = A larger, 1.875m version of the popular 1.25m Remote Guidance Unit.
 
-		#MissingHistory_MediumOreTank_title = UH-18-600 Holding Tank (Medium)  // Medium Holding Tank
+		#MissingHistory_MediumOreTank_title = UH-12-600 Holding Tank (Medium) (Missing History) // Medium Holding Tank
 
-		#MissingHistory_xenonTank_1p5_title = PB-18-X14 Xenon Container
-		#MissingHistory_xenonTank_1p5_desc = An extra-large 1.875m version of the popular PB-12-X06 xenon tank.
+		#MissingHistory_xenonTank_1p5_title = Xe-18-k14 Xenon Container
+		#MissingHistory_xenonTank_1p5_desc = An extra-large 1.875m version of the popular Xe-12-k06 xenon tank.
 
 		//#MissingHistory_liquidEngine303_title = LV-303 "Pug" Liquid Fuel Engine
 		//#MissingHistory_liquidEngineT15_title = LV-T15 "Valiant" Liquid Fuel Engine

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureExploration_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureExploration_loc.cfg
@@ -59,10 +59,10 @@ Localization
 
 
 		// Radial
-		#LOC_NFEX_nfex-fueltank-radial-tiny-1_title    = MLT-R03 Multipurpose Fuel Tank  // MLT-R2
-		#LOC_NFEX_nfex-fueltank-radial-small-3_title   = MLT-R10 Multipurpose Fuel Tank  // MLT-R5
-		#LOC_NFEX_nfex-fueltank-radial-small-1_title   = MLT-R40 Multipurpose Fuel Tank  // MLT-R20
-		#LOC_NFEX_nfex-fueltank-radial-small-2_title   = MLT-R20 Multipurpose Fuel Tank  // MLT-R10
+		#LOC_NFEX_nfex-fueltank-radial-tiny-1_title    = MLT-R-003 Multipurpose Fuel Tank  // MLT-R2
+		#LOC_NFEX_nfex-fueltank-radial-small-3_title   = MLT-R-010 Multipurpose Fuel Tank  // MLT-R5
+		#LOC_NFEX_nfex-fueltank-radial-small-1_title   = MLT-R-040 Multipurpose Fuel Tank  // MLT-R20
+		#LOC_NFEX_nfex-fueltank-radial-small-2_title   = MLT-R-020 Multipurpose Fuel Tank  // MLT-R10
 
 		#LOC_NFEX_nfex-reaction-wheel-mini-1_title     = WR Micro Control Moment Gyroscope  // Micro Control Moment Gyroscope
 		#LOC_NFEX_nfex-landing-leg-mini-1_title        = LT-009 Nano Landing Leg            // LT-9 Nano Landing Leg

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFuturePropulsion_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFuturePropulsion_loc.cfg
@@ -22,17 +22,17 @@ Localization
 		#LOC_NFPropulsion_xenon-25-3_title = PB-25-X048 Xenon Tank   // PB-Z02 Xenon Tank
 
 		// Argon Tanks
-		#LOC_NFPropulsion_argon-25-1_title          = ARG-25-10M Argon Tank
-		#LOC_NFPropulsion_argon-25-2_title          = ARG-25-05M Argon Tank
-		#LOC_NFPropulsion_argon-25-3_title          = ARG-25-02M Argon Tank
-		#LOC_NFPropulsion_argon-125-1_title         = ARG-12-1280K Argon Tank
-		#LOC_NFPropulsion_argon-125-2_title         = ARG-12-0640K Argon Tank
-		#LOC_NFPropulsion_argon-125-3_title         = ARG-12-0320K Argon Tank
-		#LOC_NFPropulsion_argon-0625-1_title        = ARG-06-112K Argon Tank
-		#LOC_NFPropulsion_argon-0625-2_title        = ARG-06-056K Argon Tank
-		#LOC_NFPropulsion_argon-0625-3_title        = ARG-06-028K Argon Tank
-		#LOC_NFPropulsion_argon-radial-0625-1_title = ARG-R101 Argon Tank
-		#LOC_NFPropulsion_argon-radial-125-1_title  = ARG-R102 Argon Tank
+		#LOC_NFPropulsion_argon-25-1_title          = ARG-25-m10 Argon Tank
+		#LOC_NFPropulsion_argon-25-2_title          = ARG-25-m05 Argon Tank
+		#LOC_NFPropulsion_argon-25-3_title          = ARG-25-m02 Argon Tank
+		#LOC_NFPropulsion_argon-125-1_title         = ARG-12-m1 Argon Tank
+		#LOC_NFPropulsion_argon-125-2_title         = ARG-12-k640 Argon Tank
+		#LOC_NFPropulsion_argon-125-3_title         = ARG-12-k320 Argon Tank
+		#LOC_NFPropulsion_argon-0625-1_title        = ARG-06-k112 Argon Tank
+		#LOC_NFPropulsion_argon-0625-2_title        = ARG-06-k056 Argon Tank
+		#LOC_NFPropulsion_argon-0625-3_title        = ARG-06-k028 Argon Tank
+		#LOC_NFPropulsion_argon-radial-0625-1_title = ARG-R-k014 Argon Tank
+		#LOC_NFPropulsion_argon-radial-125-1_title  = ARG-R-k064 Argon Tank
 
 		// Lithium Tanks
 

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFuturePropulsion_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFuturePropulsion_loc.cfg
@@ -1,5 +1,9 @@
-// NearFuturePropulsion 1.3.1
-// 2021-03-01
+// NearFuturePropulsion 1.3.5
+// 2022-01-21
+
+// Localization is pointing to the strings for the wrong part
+@PART[argon-125-3]:NEEDS[NearFuturePropulsion] { @title = Ar-12-k320 Argon Tank } 	// ARH-025M Argon Tank
+@PART[argon-125-3]:NEEDS[NearFuturePropulsion] { @description = What a small tank! Hopefully it will come in handy, because it's just too cute to ignore! } 
 
 
 Localization
@@ -11,43 +15,43 @@ Localization
 
 		// Xenon Tanks
 
-		#LOC_NFPropulsion_xenon-radial-125-1_title = PB-R75 Xenon Tank   // PB-XR9
+		#LOC_NFPropulsion_xenon-radial-125-1_title = Xe-R-k08 Xenon Tank   // PB-XR9
 
-		#LOC_NFPropulsion_xenon-125-3_title = PB-12-X06 Xenon Tank  // PB-XA26
-		#LOC_NFPropulsion_xenon-125-2_title = PB-12-X12 Xenon Tank
-		#LOC_NFPropulsion_xenon-125-1_title = PB-12-X24 Xenon Tank
+		#LOC_NFPropulsion_xenon-125-3_title = Xe-12-k06 Xenon Tank  // PB-XA26
+		#LOC_NFPropulsion_xenon-125-2_title = Xe-12-k12 Xenon Tank
+		#LOC_NFPropulsion_xenon-125-1_title = Xe-12-k24 Xenon Tank
 
-		#LOC_NFPropulsion_xenon-25-1_title = PB-25-X192 Xenon Tank   // PB-Z08 Xenon Tank
-		#LOC_NFPropulsion_xenon-25-2_title = PB-25-X096 Xenon Tank   // PB-Z04 Xenon Tank
-		#LOC_NFPropulsion_xenon-25-3_title = PB-25-X048 Xenon Tank   // PB-Z02 Xenon Tank
+		#LOC_NFPropulsion_xenon-25-1_title = Xe-25-k192 Xenon Tank   // PB-Z08 Xenon Tank
+		#LOC_NFPropulsion_xenon-25-2_title = Xe-25-k096 Xenon Tank   // PB-Z04 Xenon Tank
+		#LOC_NFPropulsion_xenon-25-3_title = Xe-25-k048 Xenon Tank   // PB-Z02 Xenon Tank
 
 		// Argon Tanks
-		#LOC_NFPropulsion_argon-25-1_title          = ARG-25-m10 Argon Tank
-		#LOC_NFPropulsion_argon-25-2_title          = ARG-25-m05 Argon Tank
-		#LOC_NFPropulsion_argon-25-3_title          = ARG-25-m02 Argon Tank
-		#LOC_NFPropulsion_argon-125-1_title         = ARG-12-m1 Argon Tank
-		#LOC_NFPropulsion_argon-125-2_title         = ARG-12-k640 Argon Tank
-		#LOC_NFPropulsion_argon-125-3_title         = ARG-12-k320 Argon Tank
-		#LOC_NFPropulsion_argon-0625-1_title        = ARG-06-k112 Argon Tank
-		#LOC_NFPropulsion_argon-0625-2_title        = ARG-06-k056 Argon Tank
-		#LOC_NFPropulsion_argon-0625-3_title        = ARG-06-k028 Argon Tank
-		#LOC_NFPropulsion_argon-radial-0625-1_title = ARG-R-k014 Argon Tank
-		#LOC_NFPropulsion_argon-radial-125-1_title  = ARG-R-k064 Argon Tank
+		#LOC_NFPropulsion_argon-25-1_title          = Ar-25-m10 Argon Tank 		 	// ARG-10M Argon Tank
+		#LOC_NFPropulsion_argon-25-2_title          = Ar-25-m05 Argon Tank  		// ARG-5M Argon Tank
+		#LOC_NFPropulsion_argon-25-3_title          = Ar-25-m03 Argon Tank  		// ARG-2M Argon Tank
+		#LOC_NFPropulsion_argon-125-1_title         = Ar-12-m1 Argon Tank  			// ARH-1M Argon Tank
+		#LOC_NFPropulsion_argon-125-2_title         = Ar-12-k640 Argon Tank  		// ARH-05M Argon Tank
+		// #LOC_NFPropulsion_argon-125-3_title         = Ar-12-k320 Argon Tank  	// ARH-025M Argon Tank
+		#LOC_NFPropulsion_argon-0625-1_title        = Ar-06-k112 Argon Tank  		// ARK-MI-112 Argon Tank
+		#LOC_NFPropulsion_argon-0625-2_title        = Ar-06-k056 Argon Tank  		// ARK-MI-56 Argon Tank
+		#LOC_NFPropulsion_argon-0625-3_title        = Ar-06-k028 Argon Tank  		// ARK-MI-28 Argon Tank
+		#LOC_NFPropulsion_argon-radial-0625-1_title = Ar-R-k014 Argon Radial Tank  // A101 Argon Tank
+		#LOC_NFPropulsion_argon-radial-125-1_title  = Ar-R-k064 Argon Radial Tank  // A102 Argon Tank
 
 		// Lithium Tanks
 
-		#LOC_NFPropulsion_lithium-radial-125-1_title  = LFR-880 Lithium Tank  // 01
-		#LOC_NFPropulsion_lithium-radial-0625-1_title = LFR-092 Lithium Tank  // 08
+		#LOC_NFPropulsion_lithium-radial-125-1_title  = Li-R-880 Lithium Radial Tank  // 01
+		#LOC_NFPropulsion_lithium-radial-0625-1_title = Li-R-092 Lithium Radial Tank  // 08
 
-		#LOC_NFPropulsion_lithium-25-1_title   = LFT-25-35 Lithium Tank      // LFT-A40
-		#LOC_NFPropulsion_lithium-25-2_title   = LFT-25-18 Lithium Tank      // LFT-A20
-		#LOC_NFPropulsion_lithium-25-3_title   = LFT-25-09 Lithium Tank      // LFT-A10
-		#LOC_NFPropulsion_lithium-125-1_title  = LFT-12-4 Lithium Tank       // LFT-B1
-		#LOC_NFPropulsion_lithium-125-2_title  = LFT-12-2 Lithium Tank       // LFT-B2
-		#LOC_NFPropulsion_lithium-125-3_title  = LFT-12-1 Lithium Tank       // LFT-B4
-		#LOC_NFPropulsion_lithium-0625-1_title = LFT-06-385 Lithium Tank     // LFT-C01
-		#LOC_NFPropulsion_lithium-0625-2_title = LFT-06-192 Lithium Tank     // LFT-C02
-		#LOC_NFPropulsion_lithium-0625-3_title = LFT-06-096 Lithium Tank     // LFT-C03
+		#LOC_NFPropulsion_lithium-25-1_title   = Li-25-k35 Lithium Tank      // LFT-A40
+		#LOC_NFPropulsion_lithium-25-2_title   = Li-25-k18 Lithium Tank      // LFT-A20
+		#LOC_NFPropulsion_lithium-25-3_title   = Li-25-k09 Lithium Tank      // LFT-A10
+		#LOC_NFPropulsion_lithium-125-1_title  = Li-12-k4 Lithium Tank       // LFT-B1
+		#LOC_NFPropulsion_lithium-125-2_title  = Li-12-k2 Lithium Tank       // LFT-B2
+		#LOC_NFPropulsion_lithium-125-3_title  = Li-12-k1 Lithium Tank       // LFT-B4
+		#LOC_NFPropulsion_lithium-0625-1_title = Li-06-385 Lithium Tank     // LFT-C01
+		#LOC_NFPropulsion_lithium-0625-2_title = Li-06-192 Lithium Tank     // LFT-C02
+		#LOC_NFPropulsion_lithium-0625-3_title = Li-06-096 Lithium Tank     // LFT-C03
 
 
 		//  Engines

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
@@ -72,16 +72,16 @@ Localization
 		#LOC_NFLaunchVehicles_nflv-separator-5-1_title            = TS-50 Separator (N-Series)              // TS-500 Stack Separator
 		#LOC_NFLaunchVehicles_nflv-fairing-5-1_title              = AE-FF4 Payload Fairing (5.0m)           // AE-FF4 Payload Fairing (5.0m)
 
-		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-5-375-1_title = Kerbodyne S3-S4-SKL-016 Adapter        // NR-AD-SKL Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-5-375-1_title          = Kerbodyne S3-S4-104 Adapter Tank       // NR-AD-10400 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-5-375-2_title          = Kerbodyne S3-S4-064 Adapter Tank       // NR-AD-6400 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-5-375-3_title          = Kerbodyne S3-S4-026 Adapter Tank       // NR-AD-2600 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-5-1_title    = Kerbodyne S4 128 Fuelled Nosecone      // NR-C-12800 Fuelled Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-round-5-1_title       = Kerbodyne S4 064 Rounded Nosecone      // NR-C-6400 Rounded Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-5-1_title             = Kerbodyne S4-512 Fuel Tank (N-Series)  // NR-51200 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-5-2_title             = Kerbodyne S4-256 Fuel Tank (N-Series)  // NR-25600 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-5-3_title             = Kerbodyne S4-128 Fuel Tank (N-Series)  // NR-12800 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-5-4_title             = Kerbodyne S4-064 Fuel Tank (N-Series)  // NR-6400 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-5-375-1_title = FV-37-50-k02 "SKL" Adapter Tank (N-Series)   // NR-AD-SKL Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-5-375-1_title          = FV-37-50-k10 Adapter Tank (N-Series)         // NR-AD-10400 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-5-375-2_title          = FV-37-50-k06 Adapter Tank (N-Series)         // NR-AD-6400 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-5-375-3_title          = FV-37-50-k03 Adapter Tank (N-Series)         // NR-AD-2600 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-5-1_title    = FS-50-k13 Fuelled Nosecone (N-Series)        // NR-C-12800 Fuelled Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-round-5-1_title       = FS-50-k06 Rounded Nosecone (N-Series)        // NR-C-6400 Rounded Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-5-1_title             = FL-50-k51 Fuel Tank (N-Series)  			 // NR-51200 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-5-2_title             = FL-50-k26 Fuel Tank (N-Series)  			 // NR-25600 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-5-3_title             = FL-50-k13 Fuel Tank (N-Series)  			 // NR-12800 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-5-4_title             = FL-50-k06 Fuel Tank (N-Series)  			 // NR-6400 Fuel Tank
 
 		#LOC_NFLaunchVehicles_nflv-adapter-5-375-4_title          = Adapter 37-50 N-Series Brand            // NR-AD-CAP Adapter
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-lower-5-1_title  = Adapter 50-L1 Lower Stage Engine Mount  // NR-L1 Lower Stage Engine Mount
@@ -103,35 +103,35 @@ Localization
 
 		// 7.5 Metre
 		// ======
-		#LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (E-Series)  // R-EX Guidance Computer Unit
+		#LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (N-Series)  // R-EX Guidance Computer Unit
 		#LOC_NFLaunchVehicles_nflv-battery-75-1_title             = Zs-75-72K Rechargeable Battery Bank      // Z-72K Rechargeable Battery Bank
-		#LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (E-Series)               // TD-750 Stack Decoupler
-		#LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (E-Series)               // TS-750 Stack Separator
-		#LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m)            // AE-FF5 Payload Fairing (7.5m)
+		#LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (N-Series)               // TD-750 Stack Decoupler
+		#LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (N-Series)               // TS-750 Stack Separator
+		#LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m) (N-Series) // AE-FF5 Payload Fairing (7.5m)
 
-		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = Kerbodyne S4-S5-SKL-117 Adapter              // EA-AD-SKL Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = Kerbodyne S4-S5-117 Adapter Tank (E-Series)  // EA-S10 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = Kerbodyne S4-S5-234 Adapter Tank (E-Series)  // EA-S20 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = Kerbodyne S5 216 Rounded Nosecone            // EA-C-64 Rounded Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = Kerbodyne S5 432 Fuelled Nosecone            // EA-C-128 Fuelled Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = Kerbodyne S5-0096 Fuel Tank (E-Series)       // EA-F96 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = Kerbodyne S5-0192 Fuel Tank (E-Series)       // EA-F192 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = Kerbodyne S5-0384 Fuel Tank (E-Series)       // EA-F384 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = Kerbodyne S5-0768 Fuel Tank (E-Series)       // EA-F768 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = Kerbodyne S5-1536 Fuel Tank (E-Series)       // EA-F1536 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = FV-50-75-k12 "SKL" Adapter Tank (N-Series)             // EA-AD-SKL Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = FV-50-75-k12 Adapter Tank (N-Series)  // EA-S10 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = FV-50-75-k23 Adapter Tank (N-Series)  // EA-S20 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = FS-75-k022 Rounded Nosecone (N-Series)           // EA-C-64 Rounded Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = FS-75-k043 Fuelled Nosecone (N-Series)           // EA-C-128 Fuelled Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = FL-75-k014 Fuel Tank (N-Series)       // EA-F96 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = FL-75-k029 Fuel Tank (N-Series)       // EA-F192 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = FL-75-k058 Fuel Tank (N-Series)       // EA-F384 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = FL-75-k115 Fuel Tank (N-Series)       // EA-F768 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = FL-75-k230 Fuel Tank (N-Series)       // EA-F1536 Fuel Tank
 
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-1_title = Adapter 75-L1 Lower Stage Engine Mount      // ER-L1 Lower Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-2_title = Adapter 75-L2 Lower Stage Engine Mount      // ER-L2 Lower Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-1_title = Adapter 75-U1 Upper Stage Engine Mount      // ER-U1 Upper Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-2_title = Adapter 75-U2 Upper Stage Engine Mount      // ER-U2 Upper Stage Engine Mount
 
-		#LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (E-Series)  // E-Series Structural Tube
-		#LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (E-Series)                  // E-Series Service Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (E-Series)                  // ECR-8 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (E-Series)                  // ECR-4 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (E-Series)                  // ECR-2 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (E-Series)                  // ECR-1 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (E-Series)             // ECR-N Nose Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (N-Series)  // E-Series Structural Tube
+		#LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (N-Series)                  // E-Series Service Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (N-Series)                  // ECR-8 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (N-Series)                  // ECR-4 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (N-Series)                  // ECR-2 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (N-Series)                  // ECR-1 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (N-Series)             // ECR-N Nose Cargo Bay
 
 
 		// Support

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
@@ -103,35 +103,35 @@ Localization
 
 		// 7.5 Metre
 		// ======
-		#LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (N-Series)  // R-EX Guidance Computer Unit
+		#LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (E-Series)  // R-EX Guidance Computer Unit
 		#LOC_NFLaunchVehicles_nflv-battery-75-1_title             = Zs-75-72K Rechargeable Battery Bank      // Z-72K Rechargeable Battery Bank
-		#LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (N-Series)               // TD-750 Stack Decoupler
-		#LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (N-Series)               // TS-750 Stack Separator
-		#LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m) (N-Series) // AE-FF5 Payload Fairing (7.5m)
+		#LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (E-Series)               // TD-750 Stack Decoupler
+		#LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (E-Series)               // TS-750 Stack Separator
+		#LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m) (E-Series) // AE-FF5 Payload Fairing (7.5m)
 
-		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = FV-50-75-k12 "SKL" Adapter Tank (N-Series)             // EA-AD-SKL Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = FV-50-75-k12 Adapter Tank (N-Series)  // EA-S10 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = FV-50-75-k23 Adapter Tank (N-Series)  // EA-S20 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = FS-75-k022 Rounded Nosecone (N-Series)           // EA-C-64 Rounded Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = FS-75-k043 Fuelled Nosecone (N-Series)           // EA-C-128 Fuelled Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = FL-75-k014 Fuel Tank (N-Series)       // EA-F96 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = FL-75-k029 Fuel Tank (N-Series)       // EA-F192 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = FL-75-k058 Fuel Tank (N-Series)       // EA-F384 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = FL-75-k115 Fuel Tank (N-Series)       // EA-F768 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = FL-75-k230 Fuel Tank (N-Series)       // EA-F1536 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = FV-50-75-k12 "SKL" Adapter Tank (E-Series)             // EA-AD-SKL Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = FV-50-75-k12 Adapter Tank (E-Series)  // EA-S10 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = FV-50-75-k23 Adapter Tank (E-Series)  // EA-S20 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = FS-75-k022 Rounded Nosecone (E-Series)           // EA-C-64 Rounded Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = FS-75-k043 Fuelled Nosecone (E-Series)           // EA-C-128 Fuelled Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = FL-75-k014 Fuel Tank (E-Series)       // EA-F96 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = FL-75-k029 Fuel Tank (E-Series)       // EA-F192 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = FL-75-k058 Fuel Tank (E-Series)       // EA-F384 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = FL-75-k115 Fuel Tank (E-Series)       // EA-F768 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = FL-75-k230 Fuel Tank (E-Series)       // EA-F1536 Fuel Tank
 
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-1_title = Adapter 75-L1 Lower Stage Engine Mount      // ER-L1 Lower Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-2_title = Adapter 75-L2 Lower Stage Engine Mount      // ER-L2 Lower Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-1_title = Adapter 75-U1 Upper Stage Engine Mount      // ER-U1 Upper Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-2_title = Adapter 75-U2 Upper Stage Engine Mount      // ER-U2 Upper Stage Engine Mount
 
-		#LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (N-Series)  // E-Series Structural Tube
-		#LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (N-Series)                  // E-Series Service Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (N-Series)                  // ECR-8 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (N-Series)                  // ECR-4 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (N-Series)                  // ECR-2 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (N-Series)                  // ECR-1 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (N-Series)             // ECR-N Nose Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (E-Series)  // E-Series Structural Tube
+		#LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (E-Series)                  // E-Series Service Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (E-Series)                  // ECR-8 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (E-Series)                  // ECR-4 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (E-Series)                  // ECR-2 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (E-Series)                  // ECR-1 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (E-Series)             // ECR-N Nose Cargo Bay
 
 
 		// Support

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RLA_Reborn_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RLA_Reborn_loc.cfg
@@ -27,14 +27,14 @@ Localization
 
 		// Tanks
 
-		#RLA_small_mptank_Part_title  = FL-R06-G0 MonoPropellant Tank    // FL-R15
-		#RLA_large_mptank_Part_title  = FL-R25-1500 MonoPropellant Tank  // FL-R200
-		#RLA_medium_mptank_Part_title = FL-R12-500 MonoPropellant Tank   // FL-R50
+		#RLA_small_mptank_Part_title  = OL-06-160 RCS Fuel Tank (RLA)   // FL-R15
+		#RLA_large_mptank_Part_title  = OL-25-k2 RCS Fuel Tank (RLA)  	// FL-R200
+		#RLA_medium_mptank_Part_title = OL-12-500 RCS Fuel Tank (RLA)   // FL-R50
 
-		#RLA_small_LFO_tank1_Part_title = FL-S30 Fuel Tank               // FS-L20 Fuel Tank
-		#RLA_small_LFO_tank2_Part_title = FL-S60 Fuel Tank               // FS-L30 Fuel Tank
-		#RLA_small_LFO_tank3_Part_title = FL-SC0 Fuel Tank               // FS-L40 Fuel Tank
-		#RLA_small_LFO_tank4_Part_title = FL-SO0 Fuel Tank               // FS-L50 Fuel Tank
+		#RLA_small_LFO_tank1_Part_title = FL-06-030 Fuel Tank (RLA)     // FS-L20 Fuel Tank
+		#RLA_small_LFO_tank2_Part_title = FL-06-060 Fuel Tank (RLA)     // FS-L30 Fuel Tank
+		#RLA_small_LFO_tank3_Part_title = FL-06-120 Fuel Tank (RLA)     // FS-L40 Fuel Tank
+		#RLA_small_LFO_tank4_Part_title = FL-06-240 Fuel Tank (RLA)     // FS-L50 Fuel Tank
 
 		#RLA_small_LFO_tank0_Part_title = R-03 Fuel Tank                                // FS-L10T Fuel Tank
 		#RLA_x_small_tank_Part_title    = PB-06-X25 Xenon Container                     // PB-X450 Xenon Container

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RLA_Reborn_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RLA_Reborn_loc.cfg
@@ -36,9 +36,9 @@ Localization
 		#RLA_small_LFO_tank3_Part_title = FL-06-120 Fuel Tank (RLA)     // FS-L40 Fuel Tank
 		#RLA_small_LFO_tank4_Part_title = FL-06-240 Fuel Tank (RLA)     // FS-L50 Fuel Tank
 
-		#RLA_small_LFO_tank0_Part_title = R-03 Fuel Tank                                // FS-L10T Fuel Tank
-		#RLA_x_small_tank_Part_title    = PB-06-X25 Xenon Container                     // PB-X450 Xenon Container
-		#RLA_tiny_mptank_rad_Part_title = Stratus-V2 Capsulified MonoPropellant Tank    // Stratus-V Capsulated MonoPropellant Tank
+		#RLA_small_LFO_tank0_Part_title = R-015 Fuel Tank (RLA)                         // FS-L10T Fuel Tank
+		#RLA_x_small_tank_Part_title    = Xe-06-k3 Xenon Container (RLA)                // PB-X450 Xenon Container
+		#RLA_tiny_mptank_rad_Part_title = OL-R-010 "Stratus V2" Capsulified MonoPropellant Tank (RLA)   // Stratus-V Capsulated MonoPropellant Tank
 
 		// Engines
 

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
@@ -78,7 +78,7 @@ Localization
 		#LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title        = FL-37-900 Hemispherical Fuel Tank (RS+) // Kerbodyne S3-1800R Hemispherical Liquid Fuel Tank
 		#LOC_RestockPlus_restock-nosecone-375-1_title                = FL-37-k04 Nosecone (RS+)                // Kerbodyne S3-3600 Nosecone
 		#LOC_RestockPlus_restock-fuel-tank-375-4_title               = FL-37-k02 Fuel Tank (RS+)               // Kerbodyne S3-1800 Tank
-		#LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_title     = XX FL-37 S3-S4-054 Adapter Tank (RS+)         // Kerbodyne SAIV Liquid Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_title     = FV-37-50-k06 Adapter Fuel Tank (RS+)    // Kerbodyne SAIV Liquid Fuel Tank Adapter
 		#LOC_RestockPlus_restock-fuel-tank-saturn-engine-1_title     = FV-50-k09 Fuelled Engine Adapter (RS+)  // Kerbodyne SIV Fuelled Engine Adapter
 		#LOC_RestockPlus_restock-fuel-tank-5-1_title                 = FL-50-k51 Fuel Tank (RS+)               // Kerbodyne SIV-512K Liquid Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-5-2_title                 = FL-50-k26 Fuel Tank (RS+)               // Kerbodyne SIV-256K Liquid Fuel Tank

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
@@ -48,21 +48,21 @@ Localization
 
 
 		// Fuel Tanks
-		#LOC_RestockPlus_restock-fuel-tank-0625-5_title            = FL-S09 Oscar-A Fuel Tank                             // Oscar-A Liquid Fuel Tank
-		#CPT_RestockPlus_miniFuelTank                              = FL-S18 Oscar-B Fuel Tank         // OSCAR-B rename!  // FL-S40 Oscar-B Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-0625-3_title            = FL-S36 Oscar-C Fuel Tank                             // Oscar-C Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-0625-2_title            = FL-S72 Oscar-D Fuel Tank                             // Oscar-D Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-0625-1_title            = FL-SE4 Oscar-E Fuel Tank                             // Oscar-E Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_title     = FL-S09 Oscar-O Hemispherical Fuel Tank               // Oscar-O Hemispherical Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-sphere-125-1_title      = FL-SW100 Hemispherical Fuel Tank                     // FL-T100-R Hemispherical Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_title     = FL-TW220 Hemispherical Fuel Tank                     // FL-TX220-R Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-0625-5_title            = FL-06-009 Oscar-A Fuel Tank (RS+)                            // Oscar-A Liquid Fuel Tank
+		#CPT_RestockPlus_miniFuelTank                              = FL-06-018 Oscar-B Fuel Tank (RS+)        // OSCAR-B rename!  // FL-S40 Oscar-B Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-0625-3_title            = FL-06-036 Oscar-C Fuel Tank (RS+)                            // Oscar-C Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-0625-2_title            = FL-06-072 Oscar-D Fuel Tank (RS+)                            // Oscar-D Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-0625-1_title            = FL-06-144 Oscar-E Fuel Tank (RS+)                            // Oscar-E Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_title     = FS-06-09 Oscar-O Hemispherical Fuel Tank               // Oscar-O Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-125-1_title      = FS-12-050 Hemispherical Fuel Tank (RS+)                    // FL-T100-R Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_title     = FS-18-220 Hemispherical Fuel Tank (RS+)                    // FL-TX220-R Hemispherical Liquid Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-sphere-25-1_title       = FW-08 Rockomax Hemispherical Fuel Tank               // Rockomax X-200-R Hemispherical Liquid Fuel Tank
 
 		#LOC_RestockPlus_restock-fuel-tank-rcs-radial-tiny-1_title = Stratus-V1 Miniature Monopropellant Tank             // Stratus-V Miniature Monopropellant Tank
-		#LOC_RestockPlus_restock-fuel-tank-rcs-1875-1_title        = FL-R18-400 RCS Fuel Tank                             // FL-R4 RCS Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-rcs-375-1_title         = FL-R37-1650 RCS Fuel Tank                            // FL-S1 RCS Fuel Tank
-		#LOC_RestockPlus_restock-oretank-1875-1_title              = UH-18-800 Holding Tank (Medium)                          // Medium Holding Tank
-		#LOC_RestockPlus_restock-oretank-375-1_title               = UH-37-3500 Holding Tank (Grande)                          // Jumbo Holding Tank
+		#LOC_RestockPlus_restock-fuel-tank-rcs-1875-1_title        = OL-18-400 RCS Fuel Tank (RS+)                        // FL-R4 RCS Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-rcs-375-1_title         = OL-37-k2 RCS Fuel Tank (RS+)                         // FL-S1 RCS Fuel Tank
+		#LOC_RestockPlus_restock-oretank-1875-1_title              = UH-18-800 Holding Tank (Medium)                      // Medium Holding Tank
+		#LOC_RestockPlus_restock-oretank-375-1_title               = UH-37-3500 Holding Tank (Grande)                     // Jumbo Holding Tank
 
 		#LOC_RestockPlus_restock-fuel-tank-1875-4_title            = FL-TX220 Fuel Tank   // FL-X220 Liquid Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-1875-3_title            = FL-TX440 Fuel Tank   // FL-X440 Liquid Fuel Tank
@@ -70,9 +70,9 @@ Localization
 		#LOC_RestockPlus_restock-fuel-tank-1875-soyuz-1_title      = FL-TXC00 "Snazzy" Fuel Tank // FL-S1200 Liquid Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-1875-1_title            = FL-TXI00 Fuel Tank   // FL-X1800 Liquid Fuel Tank
 
-		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_title  = FL-TW600 Adapter 12-18 (Long)  // FL-XA600 Fuel Tank Adapter
-		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_title  = FL-TW160 Adapter 12-18 (Short) // FL-XA160 Fuel Tank Adapter
-		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_title = FL-TW160 Adapter 06-18         // FL-XA160-S Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_title  = FL-12-18-C-600 Adapter Fuel Tank (Long)  // FL-XA600 Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_title  = FW-12-18-A-160 Adapter Fuel Tank (Short) // FL-XA160 Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_title = FW-06-18-160 Adapter Fuel Tank         // FL-XA160-S Fuel Tank Adapter
 		#LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_title   = FW-12 Rockomax Adapter 18-25   // FL-XA1200 Fuel Tank Adapter
 
 		#LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title        = Kerbodyne S3 009 Hemispherical Fuel Tank // Kerbodyne S3-1800R Hemispherical Liquid Fuel Tank

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
@@ -53,37 +53,37 @@ Localization
 		#LOC_RestockPlus_restock-fuel-tank-0625-3_title            = FL-06-036 Oscar-C Fuel Tank (RS+)                            // Oscar-C Liquid Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-0625-2_title            = FL-06-072 Oscar-D Fuel Tank (RS+)                            // Oscar-D Liquid Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-0625-1_title            = FL-06-144 Oscar-E Fuel Tank (RS+)                            // Oscar-E Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_title     = FS-06-09 Oscar-O Hemispherical Fuel Tank               // Oscar-O Hemispherical Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-sphere-125-1_title      = FS-12-050 Hemispherical Fuel Tank (RS+)                    // FL-T100-R Hemispherical Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_title     = FS-18-220 Hemispherical Fuel Tank (RS+)                    // FL-TX220-R Hemispherical Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-sphere-25-1_title       = FW-08 Rockomax Hemispherical Fuel Tank               // Rockomax X-200-R Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-0625-1_title     = FS-06-009 Oscar-O Hemispherical Fuel Tank (RS+)              // Oscar-O Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-125-1_title      = FS-12-050 Hemispherical Fuel Tank (RS+)                      // FL-T100-R Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-1875-1_title     = FS-18-220 Hemispherical Fuel Tank (RS+)                      // FL-TX220-R Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-25-1_title       = FS-25-400 Rockomax Hemispherical Fuel Tank (RS+)             // Rockomax X-200-R Hemispherical Liquid Fuel Tank
 
-		#LOC_RestockPlus_restock-fuel-tank-rcs-radial-tiny-1_title = Stratus-V1 Miniature Monopropellant Tank             // Stratus-V Miniature Monopropellant Tank
+		#LOC_RestockPlus_restock-fuel-tank-rcs-radial-tiny-1_title = OL-R-008 "Stratus V1" Miniature Monopropellant Tank (RS+)    // Stratus-V Miniature Monopropellant Tank
 		#LOC_RestockPlus_restock-fuel-tank-rcs-1875-1_title        = OL-18-400 RCS Fuel Tank (RS+)                        // FL-R4 RCS Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-rcs-375-1_title         = OL-37-k2 RCS Fuel Tank (RS+)                         // FL-S1 RCS Fuel Tank
-		#LOC_RestockPlus_restock-oretank-1875-1_title              = UH-18-800 Holding Tank (Medium)                      // Medium Holding Tank
-		#LOC_RestockPlus_restock-oretank-375-1_title               = UH-37-3500 Holding Tank (Grande)                     // Jumbo Holding Tank
+		#LOC_RestockPlus_restock-oretank-1875-1_title              = UH-18-800 Holding Tank (Medium) (RS+)                // Medium Holding Tank
+		#LOC_RestockPlus_restock-oretank-375-1_title               = UH-37-k04 Holding Tank (Grande) (RS+)               // Jumbo Holding Tank
 
-		#LOC_RestockPlus_restock-fuel-tank-1875-4_title            = FL-TX220 Fuel Tank   // FL-X220 Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-1875-3_title            = FL-TX440 Fuel Tank   // FL-X440 Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-1875-2_title            = FL-TX900 Fuel Tank   // FL-X900 Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-1875-soyuz-1_title      = FL-TXC00 "Snazzy" Fuel Tank // FL-S1200 Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-1875-1_title            = FL-TXI00 Fuel Tank   // FL-X1800 Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-1875-4_title            = FL-18-220 Fuel Tank (RS+)  // FL-X220 Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-1875-3_title            = FL-18-440 Fuel Tank (RS+)  // FL-X440 Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-1875-2_title            = FL-18-900 Fuel Tank (RS+)  // FL-X900 Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-1875-soyuz-1_title      = FV-18-k1 "Snazzy" Fuel Tank (RS+)// FL-S1200 Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-1875-1_title            = FL-18-k2 Fuel Tank (RS+)  // FL-X1800 Liquid Fuel Tank
 
-		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_title  = FL-12-18-C-600 Adapter Fuel Tank (Long)  // FL-XA600 Fuel Tank Adapter
-		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_title  = FW-12-18-A-160 Adapter Fuel Tank (Short) // FL-XA160 Fuel Tank Adapter
-		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_title = FW-06-18-160 Adapter Fuel Tank         // FL-XA160-S Fuel Tank Adapter
-		#LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_title   = FW-12 Rockomax Adapter 18-25   // FL-XA1200 Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_title  = FV-12-18-C-600 Adapter Fuel Tank (Long) (RS+)   // FL-XA600 Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_title  = FV-12-18-A-160 Adapter Fuel Tank (Short) (RS+)  // FL-XA160 Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_title = FV-06-18-160 Adapter Fuel Tank (RS+)            // FL-XA160-S Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_title   = FV-18-25-k1 Rockomax Adapter Fuel Tank (RS+)   // FL-XA1200 Fuel Tank Adapter
 
-		#LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title        = Kerbodyne S3 009 Hemispherical Fuel Tank // Kerbodyne S3-1800R Hemispherical Liquid Fuel Tank
-		#LOC_RestockPlus_restock-nosecone-375-1_title                = Kerbodyne S3 036 Nosecone                // Kerbodyne S3-3600 Nosecone
-		#LOC_RestockPlus_restock-fuel-tank-375-4_title               = Kerbodyne S3-018 Fuel Tank               // Kerbodyne S3-1800 Tank
-		#LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_title     = Kerbodyne S3-S4-054 Adapter Tank         // Kerbodyne SAIV Liquid Fuel Tank Adapter
-		#LOC_RestockPlus_restock-fuel-tank-saturn-engine-1_title     = Kerbodyne S4-090 Fuelled Engine Adapter  // Kerbodyne SIV Fuelled Engine Adapter
-		#LOC_RestockPlus_restock-fuel-tank-5-1_title                 = Kerbodyne S4-512 Fuel Tank               // Kerbodyne SIV-512K Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-5-2_title                 = Kerbodyne S4-256 Fuel Tank               // Kerbodyne SIV-256K Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-5-3_title                 = Kerbodyne S4-128 Fuel Tank               // Kerbodyne SIV-128K Liquid Fuel Tank
-		#LOC_RestockPlus_restock-fuel-tank-5-4_title                 = Kerbodyne S4-064 Fuel Tank               // Kerbodyne SIV-64K Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title        = FL-37-900 Hemispherical Fuel Tank (RS+) // Kerbodyne S3-1800R Hemispherical Liquid Fuel Tank
+		#LOC_RestockPlus_restock-nosecone-375-1_title                = FL-37-k04 Nosecone (RS+)                // Kerbodyne S3-3600 Nosecone
+		#LOC_RestockPlus_restock-fuel-tank-375-4_title               = FL-37-k02 Fuel Tank (RS+)               // Kerbodyne S3-1800 Tank
+		#LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_title     = XX FL-37 S3-S4-054 Adapter Tank (RS+)         // Kerbodyne SAIV Liquid Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-saturn-engine-1_title     = FV-50-k09 Fuelled Engine Adapter (RS+)  // Kerbodyne SIV Fuelled Engine Adapter
+		#LOC_RestockPlus_restock-fuel-tank-5-1_title                 = FL-50-k51 Fuel Tank (RS+)               // Kerbodyne SIV-512K Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-5-2_title                 = FL-50-k26 Fuel Tank (RS+)               // Kerbodyne SIV-256K Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-5-3_title                 = FL-50-k13 Fuel Tank (RS+)               // Kerbodyne SIV-128K Liquid Fuel Tank
+		#LOC_RestockPlus_restock-fuel-tank-5-4_title                 = FL-50-k06 Fuel Tank (RS+)               // Kerbodyne SIV-64K Liquid Fuel Tank
 
 		//#LOC_RestockPlus_restock-fuel-tank-probe-2_title = PRBE-4 Liquid Fuel Tank
 		//#LOC_RestockPlus_restock-fuel-tank-probe-1_title = PRBE-9 Liquid Fuel Tank

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
@@ -13,8 +13,8 @@ Localization
 
         #LOC_SSR_microXenon_title           = PB-03-24 Octagonal Xenon Container (Micro)        // SSR Micro Xenon Container
         #LOC_SSR_radialXenonmicro_title     = PB-R002 Radial Xenon Container (Micro)            // SSR Micro Radial Xenon Container
-		#LOC_SSR_625liquidFuel_title        = FL-S080 Fuel Tank (SSR)                           // 0.625m Fuel Tank
-		#LOC_SSR_microlqdfuel_title         = FL-Q14 MicroSat Liquid Fuel Tank (SSR)            // SSR MicroSat Liquid Fuel Tank
+		#LOC_SSR_625liquidFuel_title        = FL-06-80 Fuel Tank (SSR)                          // 0.625m Fuel Tank
+		#LOC_SSR_microlqdfuel_title         = FL-03-14 MicroSat Liquid Fuel Tank (SSR)           // SSR MicroSat Liquid Fuel Tank
         
 		#LOC_SSR_microsatEngine_title       = LV-0-4 Microsat Liquid Fuel Engine (SSR) 			// SSR Microsat Liquid Fuel Engine
         #LOC_SSR_solidBoosterMini_title     = SRB-06-06 "Thumper" MiniRocket (SSR)              // SRB625 "Thumper" MiniRocket

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
@@ -11,10 +11,10 @@ Localization
 	{
 		#LOC_SSR_MicroSat_title             = RC-0 MicroSat (SSR)                               // SSR MicroSat
 
-        #LOC_SSR_microXenon_title           = PB-03-24 Octagonal Xenon Container (Micro)        // SSR Micro Xenon Container
-        #LOC_SSR_radialXenonmicro_title     = PB-R002 Radial Xenon Container (Micro)            // SSR Micro Radial Xenon Container
-		#LOC_SSR_625liquidFuel_title        = FL-06-80 Fuel Tank (SSR)                          // 0.625m Fuel Tank
-		#LOC_SSR_microlqdfuel_title         = FL-03-14 MicroSat Liquid Fuel Tank (SSR)           // SSR MicroSat Liquid Fuel Tank
+        #LOC_SSR_microXenon_title           = Xe-03-24 Octagonal Xenon Container (Micro)        // SSR Micro Xenon Container
+        #LOC_SSR_radialXenonmicro_title     = Xe-R-015 Radial Xenon Container (Micro)           // SSR Micro Radial Xenon Container
+		#LOC_SSR_625liquidFuel_title        = FL-06-080 Fuel Tank (SSR)                         // 0.625m Fuel Tank
+		#LOC_SSR_microlqdfuel_title         = FL-03-14 MicroSat Liquid Fuel Tank (SSR)          // SSR MicroSat Liquid Fuel Tank
         
 		#LOC_SSR_microsatEngine_title       = LV-0-4 Microsat Liquid Fuel Engine (SSR) 			// SSR Microsat Liquid Fuel Engine
         #LOC_SSR_solidBoosterMini_title     = SRB-06-06 "Thumper" MiniRocket (SSR)              // SRB625 "Thumper" MiniRocket
@@ -39,4 +39,6 @@ Localization
     }
 }
 
-
+// Conditional Parts included with the mod
+@PART[microArgon]:NEEDS[SquiggsySpaceResearch,NearFuturePropulsion]:AFTER[SquiggsySpaceResearch] { @title = Ar-03-k4 Octagonal Argon Container (Micro)  }    // Micro Argon Container
+@PART[microCapacitor]:NEEDS[SquiggsySpaceResearch,NearFutureElectrical]:AFTER[SquiggsySpaceResearch] { @title = ZZ-200 Micro Capacitor (SSR) }               // Micro Capacitor

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
@@ -40,5 +40,5 @@ Localization
 }
 
 // Conditional Parts included with the mod
-@PART[microArgon]:NEEDS[SquiggsySpaceResearch,NearFuturePropulsion]:AFTER[SquiggsySpaceResearch] { @title = Ar-03-k4 Octagonal Argon Container (Micro)  }    // Micro Argon Container
-@PART[microCapacitor]:NEEDS[SquiggsySpaceResearch,NearFutureElectrical]:AFTER[SquiggsySpaceResearch] { @title = ZZ-200 Micro Capacitor (SSR) }               // Micro Capacitor
+@PART[microArgon]:NEEDS[NearFuturePropulsion]:AFTER[SquiggsySpaceResearch]      { @title = Ar-03-k4 Octagonal Argon Container (Micro)   }  // Micro Argon Container
+@PART[microCapacitor]:NEEDS[NearFutureElectrical]:AFTER[SquiggsySpaceResearch]  { @title = ZZ-200 Micro Capacitor (SSR)                 }  // Micro Capacitor

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_StockishProjectOrion_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_StockishProjectOrion_loc.cfg
@@ -10,16 +10,16 @@ Localization
 		#LOC_SPO_Conn_Name = Mk1-18 Orion Command Capsule  // Orion Command Capsule
 		
 		// Tanks
-		#LOC_SPO_smallMag_Name = Orion Magazine-B (Small)    // Small Orion Magazine
-		#LOC_SPO_medMag_Name   = Orion Magazine-C (Medium)   // Medium Orion Magazine
-		#LOC_SPO_largeMag_Name = Orion Magazine-D (Large)    // Large Orion Magazine
+		#LOC_SPO_smallMag_Name = Orion Magazine 18-060    // Small Orion Magazine
+		#LOC_SPO_medMag_Name   = Orion Magazine 18-120    // Medium Orion Magazine
+		#LOC_SPO_largeMag_Name = Orion Magazine 18-240    // Large Orion Magazine
 
-		#LOC_SPO_largeLFO_Name = FS-191 Fuel Tank            // FS-191 Fuel Tank
-		#LOC_SPO_medLFO_Name   = FS-095 Fuel Tank            // FS-95 Fuel Tank
-		#LOC_SPO_shortLFO_Name = FS-047 Fuel Tank            // FS-47 Fuel Tank	
+		#LOC_SPO_largeLFO_Name = FL-18-k2 "FS" Fuel Tank (Orion)           // FS-191 Fuel Tank
+		#LOC_SPO_medLFO_Name   = FL-18-950 "FS" Fuel Tank (Orion)          // FS-95 Fuel Tank
+		#LOC_SPO_shortLFO_Name = FL-18-470 "FS" Fuel Tank (Orion)          // FS-47 Fuel Tank	
 
-		#LOC_SPO_shortRCS_Name = LF-R18-468 RCS Fuel Tank (Orion)  // FS-R46 RCS Fuel Tank
-		#LOC_SPO_medRCS_Name   = LF-R18-936 RCS Fuel Tank (Orion)  // FS-R93 RCS Fuel Tank
+		#LOC_SPO_shortRCS_Name = OL-18-468 RCS Fuel Tank (Orion)  // FS-R46 RCS Fuel Tank
+		#LOC_SPO_medRCS_Name   = OL-18-936 RCS Fuel Tank (Orion)  // FS-R93 RCS Fuel Tank
 		
 		#LOC_SPO_medOre_Name      = UR-1 Radial Ore Container                  // Medium Radial Ore Tank
 		#LOC_SPO_medMetalOre_Name = UR-2 Radial Metallic Ore Container         // Medium Metallic Ore Ore Tank

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
@@ -8,8 +8,8 @@
 @PART[SR_InlineProbe]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = RC-03 'Umbra' Probe Core M-315	}  // M-315 Probe Core
 
 // Fuel Tanks
-@PART[SR_Tank_625_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-S100 Fuel Tank				}  // SR-625A Fuel Tank
-@PART[SR_Tank_35_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-Q20 Fuel Tank					}  // SR-35A Fuel Tank
+@PART[SR_Tank_625_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-S100 Fuel Tank (SR)               }  // SR-625A Fuel Tank
+@PART[SR_Tank_35_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-03-22 Fuel Tank (SR)              }  // SR-35A Fuel Tank
 
 // Engine
 @PART[SR_Aerospike]:NEEDS[UmbraSpaceIndustries/SoundingRockets]				{ @title = JT-0 Mini Aerospike Engine				}  // Mini Aerospike Engine

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_USI_Sounding_Rockets.cfg
@@ -8,7 +8,7 @@
 @PART[SR_InlineProbe]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = RC-03 'Umbra' Probe Core M-315	}  // M-315 Probe Core
 
 // Fuel Tanks
-@PART[SR_Tank_625_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-S100 Fuel Tank (SR)               }  // SR-625A Fuel Tank
+@PART[SR_Tank_625_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-06-100 Fuel Tank (SR)               }  // SR-625A Fuel Tank
 @PART[SR_Tank_35_01]:NEEDS[UmbraSpaceIndustries/SoundingRockets]			{ @title = FL-03-22 Fuel Tank (SR)              }  // SR-35A Fuel Tank
 
 // Engine

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
@@ -79,17 +79,17 @@ Localization
 		#autoLOC_500544  = FL-25-32 Rockomax Fuel Tank             // Rockomax X200-32 Fuel Tank
 		#autoLOC_500520  = FL-25-64 Rockomax "Jumbo" Fuel Tank     // Rockomax Jumbo-64 Fuel Tank
 
-		#autoLOC_500742 =  FL-S2-S3-030 Kerbodyne Adapter Tank         // Kerbodyne ADTP-2-3
+		#autoLOC_500742 =  FV-25-37-030 Kerbodyne Adapter Tank         // Kerbodyne ADTP-2-3
 
-		#autoLOC_500619  = FL-S3-072 Kerbodyne Fuel Tank          			// Kerbodyne S3-7200 Tank
-		#autoLOC_500622  = FL-S3-036 Kerbodyne Fuel Tank          			// Kerbodyne S3-3600 Tank
-		#autoLOC_500616  = FL-S3-144 Kerbodyne Fuel Tank          			// Kerbodyne S3-14400 Tank
-		#autoLOC_8310111 = FL-S3-S4-064 Kerbodyne Adapter Tank    			// Kerbodyne S3-S4 Adapter Tank
-		#autoLOC_8310117 = FL-S4-064 Kerbodyne Fuel Tank          			// Kerbodyne S4-64 Fuel Tank
-		#autoLOC_8310120 = FL-S4-128 Kerbodyne Fuel Tank          			// Kerbodyne S4-128 Fuel Tank
-		#autoLOC_8310123 = FL-S4-256 Kerbodyne Fuel Tank          			// Kerbodyne S4-256 Fuel Tank
-		#autoLOC_8310126 = FL-S4-512 Kerbodyne Fuel Tank          			// Kerbodyne S4-512 Fuel Tank
-		#autoLOC_8310114 = FL-S4-090 Kerbodyne Engine Cluster Adapter Tank //Kerbodyne Engine Cluster Adapter Tank
+		#autoLOC_500619  = FL-37-072 Kerbodyne Fuel Tank          			// Kerbodyne S3-7200 Tank
+		#autoLOC_500622  = FL-37-036 Kerbodyne Fuel Tank          			// Kerbodyne S3-3600 Tank
+		#autoLOC_500616  = FL-37-144 Kerbodyne Fuel Tank          			// Kerbodyne S3-14400 Tank
+		#autoLOC_8310111 = FL-37-50-064 Kerbodyne Adapter Tank    			// Kerbodyne S3-S4 Adapter Tank
+		#autoLOC_8310117 = FL-50-064 Kerbodyne Fuel Tank          			// Kerbodyne S4-64 Fuel Tank
+		#autoLOC_8310120 = FL-50-128 Kerbodyne Fuel Tank          			// Kerbodyne S4-128 Fuel Tank
+		#autoLOC_8310123 = FL-50-256 Kerbodyne Fuel Tank          			// Kerbodyne S4-256 Fuel Tank
+		#autoLOC_8310126 = FL-50-512 Kerbodyne Fuel Tank          			// Kerbodyne S4-512 Fuel Tank
+		#autoLOC_8310114 = FL-50-090 Kerbodyne Engine Cluster Adapter Tank  //Kerbodyne Engine Cluster Adapter Tank
 
 		#autoLOC_500550 = Mk0 Liquid Fuel Fuselage-C           // Mk0 Liquid Fuel Fuselage
 		#autoLOC_500730 = Mk1 Liquid Fuel Fuselage-C           // Mk1 Liquid Fuel Fuselage

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
@@ -350,11 +350,11 @@ Localization
 		// #autoLOC_500978 = LY-60 Large Landing Gear         // LY-60
 		// #autoLOC_500969 = LY-99 Extra Large Landing Gear   // LY-99
 
-		#autoLOC_500990 =  RoveMax Model G2                   // RoveMax Model S2
+		#autoLOC_500990  = RoveMax Model G2                   // RoveMax Model S2
 		#autoLOC_8310129 = RoveMax Model M0                   // RoveMax M1-F Rover Wheel
-		#autoLOC_500987 =  RoveMax Model M1
-		#autoLOC_500993 =  RoveMax Model TR-2L 'Ruggedized'   // TR-2L Ruggedized Vehicular Wheel
-		#autoLOC_500996 =  RoveMax Model XL3
+		#autoLOC_500987  = RoveMax Model M1
+		#autoLOC_500993  = RoveMax Model TR-2L 'Ruggedized'   // TR-2L Ruggedized Vehicular Wheel
+		#autoLOC_500996  = RoveMax Model XL3
 
 
 		// THERMAL

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
@@ -6,14 +6,14 @@ Localization
 	en-us
 	{
 		// 1.3
-		#autoLOC_500838 = TR-06 Stack Decoupler           //TR-02V Stack Decoupler
-		#autoLOC_500835 = TR-12 Stack Decoupler           //TR-18A Stack Decoupler
-		#autoLOC_500832 = TR-25 Stack Decoupler           //TR-20 Rockomax Brand Decoupler
-		#autoLOC_500739 = TR-37 Stack Decoupler           //TR-38D Stack Decoupler
+		#autoLOC_500838 = TR-06 Stack Decoupler           // TR-02V Stack Decoupler
+		#autoLOC_500835 = TR-12 Stack Decoupler           // TR-18A Stack Decoupler
+		#autoLOC_500832 = TR-25 Stack Decoupler           // TR-20 Rockomax Brand Decoupler
+		#autoLOC_500739 = TR-37 Stack Decoupler           // TR-38D Stack Decoupler
 
-		#autoLOC_500826 = TM-06 Stack Separator           //TM-02C Stack Separator
-		#autoLOC_500823 = TM-12 Stack Separator           //TM-18D Stack Separator
-		#autoLOC_500829 = TM-25 Stack Separator           //TM-XL Stack Separator
+		#autoLOC_500826 = TM-06 Stack Separator           // TM-02C Stack Separator
+		#autoLOC_500823 = TM-12 Stack Separator           // TM-18D Stack Separator
+		#autoLOC_500829 = TM-25 Stack Separator           // TM-XL Stack Separator
 
 		#autoLOC_500304 = Mk1-2 Command Pod (Old)                // Mk1-2 Command Pod
 		#autoLOC_500538 = R-8 'ROUND' Toroidal Fuel Tank (Old)   // ROUND-8 Toroidal Fuel Tank
@@ -28,7 +28,7 @@ Localization
 		#autoLOC_500328 = Mk2 Drone Core       // MK2 Drone Core
 
 		#autoLOC_8310154 = Mk1-18 Command Pod  // Mk2 Command Pod
-		#autoLOC_501805 =  Mk1-25 Command Pod  // Mk1-3 Command Pod
+		#autoLOC_501805  = Mk1-25 Command Pod  // Mk1-3 Command Pod
 
 		#autoLOC_500316 = Lk1 Lander Can
 		#autoLOC_500331 = Lk2 Lander Can
@@ -193,13 +193,13 @@ Localization
 		#autoLOC_500894  = RV-105 'Place-Anywhere 7' Linear RCS Port    // Place-Anywhere 7 Linear RCS Port
 
 		#autoLOC_8003432 = RV-01X RCS Thruster Block                    // RV-1X Variable Thruster Block
-		#autoLOC_500939 = RV-105 RCS Thruster Block                     // RV-105 RCS Thruster Block
+		#autoLOC_500939  = RV-105 RCS Thruster Block                    // RV-105 RCS Thruster Block
 
 		#autoLOC_500298 = WR-12 Advanced Inline Stabilizer              // Advanced Inline Stabilizer
 		#autoLOC_500286 = WR-25 Advanced Reaction Wheel Module (Large)  // Advanced Reaction Wheel Module, Large
 		#autoLOC_500301 = WR-06 Inline Reaction Wheel (Small)           // Small Inline Reaction Wheel
 
-		//#autoLOC_500148 = CH-J3 Fly-By-Wire Avionics Hub              // CH-J3 Fly-By-Wire Avionics Hub
+		// #autoLOC_500148 = CH-J3 Fly-By-Wire Avionics Hub             // CH-J3 Fly-By-Wire Avionics Hub
 		// #autoLOC_500493 = Vernor Engine                              // Vernor Engine              - Generic (not strictly a vernier engine)
 
 		// STRUCTURAL
@@ -239,7 +239,7 @@ Localization
 
 		// COUPLING
 
-		//#autoLOC_6002506 = Advanced Grabbing Unit Jr.
+		// #autoLOC_6002506 = Advanced Grabbing Unit Jr.
 		#autoLOC_500861  = Advanced Grabbing Unit Mr.                     // Advanced Grabbing Unit
 
 		#autoLOC_8310003 = Clamp-O-Tron Docking Airlock (Jr, Inflatable)  // Inflatable Airlock

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
@@ -54,7 +54,11 @@ Localization
 		#autoLOC_8310056 = FL-R18-400 RCS Fuel Tank            // FL-R400 RCS Fuel Tank
 		#autoLOC_500601  = FL-R25-0750 RCS Fuel Tank           // FL-R750 RCS Fuel Tank
 
-		#autoLOC_500523 = FL-S40 Oscar-B Fuel Tank
+		#autoLOC_500523 = FL-06-40 Oscar-B Liquid Fuel Tank   // Oscar-B Fuel Tank
+		#autoLOC_500526 = FL-12-100 Liquid Fuel Tank          // FL-T100 Fuel Tank
+		#autoLOC_500529 = FL-12-200 Liquid Fuel Tank          // FL-T200 Fuel Tank
+		#autoLOC_500532 = FL-12-400 Liquid Fuel Tank          // FL-T400 Fuel Tank
+		#autoLOC_500535 = FL-12-800 Liquid Fuel Tank          // FL-T800 Fuel Tank
 
 		#autoLOC_8310084 = FL-TW160 Adapter 06-18             // FL-A150 Fuel Tank Adapter
 		#autoLOC_8310087 = FL-TW600 Adapter 12-18 (Long)      // FL-A151L Fuel Tank Adapter
@@ -66,26 +70,26 @@ Localization
 		#autoLOC_8310108 = FL-TXC00 "Snazzy" Fuel Tank        // FL-C1000 Fuel Tank
 		#autoLOC_8310105 = FL-TXI00 Fuel Tank                 // FL-TX1800 Fuel Tank
 
-		#autoLOC_500511  = FV-08 Rockomax Adapter 12-25            // C7 Brand Adapter - 2.5m to 1.25m
-		#autoLOC_500514  = FV-08 Rockomax Adapter 12-25 (Slanted)  // C7 Brand Adapter Slanted - 2.5m to 1.25m
-		#autoLOC_8310093 = FW-12 Rockomax Adapter 18-25            // FL-A215 Fuel Tank Adapter
+		#autoLOC_500511  = FV-12-25-08 Rockomax Adapter            // C7 Brand Adapter - 2.5m to 1.25m
+		#autoLOC_500514  = FV-12-25-08 Rockomax Adapter (Slanted)  // C7 Brand Adapter Slanted - 2.5m to 1.25m
+		#autoLOC_8310093 = FW-18-25-12 Rockomax Adapter            // FL-A215 Fuel Tank Adapter
 
-		#autoLOC_500547  = FX-08 Rockomax Fuel Tank             // Rockomax X200-8 Fuel Tank
-		#autoLOC_500541  = FX-16 Rockomax Fuel Tank             // Rockomax X200-16 Fuel Tank
-		#autoLOC_500544  = FX-32 Rockomax Fuel Tank             // Rockomax X200-32 Fuel Tank
-		#autoLOC_500520  = FX-64 Rockomax "Jumbo" Fuel Tank     // Rockomax Jumbo-64 Fuel Tank
+		#autoLOC_500547  = FL-25-08 Rockomax Fuel Tank             // Rockomax X200-8 Fuel Tank
+		#autoLOC_500541  = FL-25-16 Rockomax Fuel Tank             // Rockomax X200-16 Fuel Tank
+		#autoLOC_500544  = FL-25-32 Rockomax Fuel Tank             // Rockomax X200-32 Fuel Tank
+		#autoLOC_500520  = FL-25-64 Rockomax "Jumbo" Fuel Tank     // Rockomax Jumbo-64 Fuel Tank
 
-		#autoLOC_500742 = Kerbodyne S2-S3-030 Adapter Tank         // Kerbodyne ADTP-2-3
+		#autoLOC_500742 =  FL-S2-S3-030 Kerbodyne Adapter Tank         // Kerbodyne ADTP-2-3
 
-		#autoLOC_500619  = Kerbodyne S3-072 Fuel Tank          			// Kerbodyne S3-7200 Tank
-		#autoLOC_500622  = Kerbodyne S3-036 Fuel Tank          			// Kerbodyne S3-3600 Tank
-		#autoLOC_500616  = Kerbodyne S3-144 Fuel Tank          			// Kerbodyne S3-14400 Tank
-		#autoLOC_8310111 = Kerbodyne S3-S4-064 Adapter Tank    			// Kerbodyne S3-S4 Adapter Tank
-		#autoLOC_8310117 = Kerbodyne S4-064 Fuel Tank          			// Kerbodyne S4-64 Fuel Tank
-		#autoLOC_8310120 = Kerbodyne S4-128 Fuel Tank          			// Kerbodyne S4-128 Fuel Tank
-		#autoLOC_8310123 = Kerbodyne S4-256 Fuel Tank          			// Kerbodyne S4-256 Fuel Tank
-		#autoLOC_8310126 = Kerbodyne S4-512 Fuel Tank          			// Kerbodyne S4-512 Fuel Tank
-		#autoLOC_8310114 = Kerbodyne S4-090 Engine Cluster Adapter Tank //Kerbodyne Engine Cluster Adapter Tank
+		#autoLOC_500619  = FL-S3-072 Kerbodyne Fuel Tank          			// Kerbodyne S3-7200 Tank
+		#autoLOC_500622  = FL-S3-036 Kerbodyne Fuel Tank          			// Kerbodyne S3-3600 Tank
+		#autoLOC_500616  = FL-S3-144 Kerbodyne Fuel Tank          			// Kerbodyne S3-14400 Tank
+		#autoLOC_8310111 = FL-S3-S4-064 Kerbodyne Adapter Tank    			// Kerbodyne S3-S4 Adapter Tank
+		#autoLOC_8310117 = FL-S4-064 Kerbodyne Fuel Tank          			// Kerbodyne S4-64 Fuel Tank
+		#autoLOC_8310120 = FL-S4-128 Kerbodyne Fuel Tank          			// Kerbodyne S4-128 Fuel Tank
+		#autoLOC_8310123 = FL-S4-256 Kerbodyne Fuel Tank          			// Kerbodyne S4-256 Fuel Tank
+		#autoLOC_8310126 = FL-S4-512 Kerbodyne Fuel Tank          			// Kerbodyne S4-512 Fuel Tank
+		#autoLOC_8310114 = FL-S4-090 Kerbodyne Engine Cluster Adapter Tank //Kerbodyne Engine Cluster Adapter Tank
 
 		#autoLOC_500550 = Mk0 Liquid Fuel Fuselage-C           // Mk0 Liquid Fuel Fuselage
 		#autoLOC_500730 = Mk1 Liquid Fuel Fuselage-C           // Mk1 Liquid Fuel Fuselage

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
@@ -49,10 +49,10 @@ Localization
 		#autoLOC_500361  = AFD-2 External Fuel Duct            // FTX-2 External Fuel Duct
 		#autoLOC_6006005 = AFV-1 Drain Valve                   // FTE-1 Drain Valve
 
-		#autoLOC_500604  = OL-06-20 RCS Fuel Tank             // FL-R20 RCS Fuel Tank
+		#autoLOC_500604  = OL-06-020 RCS Fuel Tank             // FL-R20 RCS Fuel Tank
 		#autoLOC_500607  = OL-12-120 RCS Fuel Tank            // FL-R120 RCS Fuel Tank
 		#autoLOC_8310056 = OL-18-400 RCS Fuel Tank            // FL-R400 RCS Fuel Tank
-		#autoLOC_500601  = OL-25-0750 RCS Fuel Tank           // FL-R750 RCS Fuel Tank
+		#autoLOC_500601  = OL-25-750 RCS Fuel Tank           // FL-R750 RCS Fuel Tank
 
 		#autoLOC_500523 = FL-06-40 Oscar-B Liquid Fuel Tank   // Oscar-B Fuel Tank
 		#autoLOC_500526 = FL-12-100 Liquid Fuel Tank          // FL-T100 Fuel Tank
@@ -64,14 +64,14 @@ Localization
 		#autoLOC_8310087 = FV-12-18-600 Adapter (Long)        // FL-A151L Fuel Tank Adapter
 		#autoLOC_8310090 = FV-12-18-160 Adapter (Short)       // FL-A151S Fuel Tank Adapter
 
-		#autoLOC_8310096 = FL-TX220 Fuel Tank                 // FL-TX220 Fuel Tank
-		#autoLOC_8310099 = FL-TX440 Fuel Tank                 // FL-TX440 Fuel Tank
-		#autoLOC_8310102 = FL-TX900 Fuel Tank                 // FL-TX900 Fuel Tank
-		#autoLOC_8310108 = FL-TXC00 "Snazzy" Fuel Tank        // FL-C1000 Fuel Tank
-		#autoLOC_8310105 = FL-TXI00 Fuel Tank                 // FL-TX1800 Fuel Tank
+		#autoLOC_8310096 = FL-18-220 Fuel Tank                 // FL-TX220 Fuel Tank
+		#autoLOC_8310099 = FL-18-440 Fuel Tank                 // FL-TX440 Fuel Tank
+		#autoLOC_8310102 = FL-18-900 Fuel Tank                 // FL-TX900 Fuel Tank
+		#autoLOC_8310108 = FS-18-k01 "Snazzy" Fuel Tank        // FL-C1000 Fuel Tank
+		#autoLOC_8310105 = FL-18-k02 Fuel Tank                 // FL-TX1800 Fuel Tank
 
-		#autoLOC_500511  = FV-12-25-08 Rockomax Adapter            // C7 Brand Adapter - 2.5m to 1.25m
-		#autoLOC_500514  = FV-12-25-08 Rockomax Adapter (Slanted)  // C7 Brand Adapter Slanted - 2.5m to 1.25m
+		#autoLOC_500511  = FV-12-25-800 C7 Adapter Tank            // C7 Brand Adapter - 2.5m to 1.25m
+		#autoLOC_500514  = FV-12-25-800 C7 Adapter Tank (Slanted)  // C7 Brand Adapter Slanted - 2.5m to 1.25m
 		#autoLOC_8310093 = FV-18-25-12 Rockomax Adapter            // FL-A215 Fuel Tank Adapter
 
 		#autoLOC_500547  = FL-25-800 Rockomax Fuel Tank             // Rockomax X200-8 Fuel Tank
@@ -117,21 +117,21 @@ Localization
 		#autoLOC_500586 = Mk3 Rocket Fuel Fuselage-C           // Mk3 Rocket Fuel Fuselage
 		#autoLOC_500598 = Mk3 Monopropellant Fuselage-A        // Mk3 Monopropellant Tank
 
-		#autoLOC_500631 = PB-R04 Xenon Container    // PB-X50R
-		#autoLOC_500625 = PB-06-07 Xenon Container // PB-X150 Xenon Container
-		#autoLOC_500628 = PB-12-06 Xenon Container // PB-X750 Xenon Container
+		#autoLOC_500631 = Xe-R-405 Xenon Container    // PB-X50R
+		#autoLOC_500625 = Xe-06-720 Xenon Container // PB-X150 Xenon Container
+		#autoLOC_500628 = Xe-12-k05 Xenon Container // PB-X750 Xenon Container
 
-		#autoLOC_8310074 = Stratus-V1 Minified Monopropellant Tank      // Stratus-V Minified Monopropellant Tank
-		#autoLOC_500610  = Stratus-V3 Roundified Monopropellant Tank    // Stratus-V Roundified Monopropellant Tank
-		#autoLOC_500613  = Stratus-V5 Cylindrified Monopropellant Tank  // Stratus-V Cylindrified Monopropellant Tank
+		#autoLOC_8310074 = OL-R-008 "Stratus V1" Minified Monopropellant Tank      // Stratus-V Minified Monopropellant Tank
+		#autoLOC_500610  = OL-R-020 "Stratus V3" Roundified Monopropellant Tank    // Stratus-V Roundified Monopropellant Tank
+		#autoLOC_500613  = OL-R-050 "Stratus V5" Cylindrified Monopropellant Tank  // Stratus-V Cylindrified Monopropellant Tank
 
-		#autoLOC_501808 = R-11 'Baguette' External Tank
-		#autoLOC_501811 = R-04 'Dumpling' External Tank     // R-4 'Dumpling' External Tank
-		#autoLOC_501814 = R-12 'Doughnut' External Tank
+		#autoLOC_501808 = R-054 'Baguette' External Tank
+		#autoLOC_501811 = R-020 'Dumpling' External Tank     // R-4 'Dumpling' External Tank
+		#autoLOC_501814 = R-060 'Doughnut' External Tank
 
-		#autoLOC_500670 = UH-01 Holding Tank (Radial)       // Radial Holding Tank
+		#autoLOC_500670 = UH-R-075 Holding Tank (Radial)       // Radial Holding Tank
 		#autoLOC_500673 = UH-12-300 Holding Tank (Small)    // Small Holding Tank
-		#autoLOC_500655 = UH-25-1500 Holding Tank (Large)   // Large Holding Tank
+		#autoLOC_500655 = UH-25-k02 Holding Tank (Large)   // Large Holding Tank
 
 		// ENGINES
 

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
@@ -49,10 +49,10 @@ Localization
 		#autoLOC_500361  = AFD-2 External Fuel Duct            // FTX-2 External Fuel Duct
 		#autoLOC_6006005 = AFV-1 Drain Valve                   // FTE-1 Drain Valve
 
-		#autoLOC_500604  = FL-R06-20 RCS Fuel Tank             // FL-R20 RCS Fuel Tank
-		#autoLOC_500607  = FL-R12-120 RCS Fuel Tank            // FL-R120 RCS Fuel Tank
-		#autoLOC_8310056 = FL-R18-400 RCS Fuel Tank            // FL-R400 RCS Fuel Tank
-		#autoLOC_500601  = FL-R25-0750 RCS Fuel Tank           // FL-R750 RCS Fuel Tank
+		#autoLOC_500604  = OL-06-20 RCS Fuel Tank             // FL-R20 RCS Fuel Tank
+		#autoLOC_500607  = OL-12-120 RCS Fuel Tank            // FL-R120 RCS Fuel Tank
+		#autoLOC_8310056 = OL-18-400 RCS Fuel Tank            // FL-R400 RCS Fuel Tank
+		#autoLOC_500601  = OL-25-0750 RCS Fuel Tank           // FL-R750 RCS Fuel Tank
 
 		#autoLOC_500523 = FL-06-40 Oscar-B Liquid Fuel Tank   // Oscar-B Fuel Tank
 		#autoLOC_500526 = FL-12-100 Liquid Fuel Tank          // FL-T100 Fuel Tank
@@ -60,9 +60,9 @@ Localization
 		#autoLOC_500532 = FL-12-400 Liquid Fuel Tank          // FL-T400 Fuel Tank
 		#autoLOC_500535 = FL-12-800 Liquid Fuel Tank          // FL-T800 Fuel Tank
 
-		#autoLOC_8310084 = FL-TW160 Adapter 06-18             // FL-A150 Fuel Tank Adapter
-		#autoLOC_8310087 = FL-TW600 Adapter 12-18 (Long)      // FL-A151L Fuel Tank Adapter
-		#autoLOC_8310090 = FL-TW160 Adapter 12-18 (Short)     // FL-A151S Fuel Tank Adapter
+		#autoLOC_8310084 = FV-06-18-160 Adapter               // FL-A150 Fuel Tank Adapter
+		#autoLOC_8310087 = FV-12-18-600 Adapter (Long)        // FL-A151L Fuel Tank Adapter
+		#autoLOC_8310090 = FV-12-18-160 Adapter (Short)       // FL-A151S Fuel Tank Adapter
 
 		#autoLOC_8310096 = FL-TX220 Fuel Tank                 // FL-TX220 Fuel Tank
 		#autoLOC_8310099 = FL-TX440 Fuel Tank                 // FL-TX440 Fuel Tank
@@ -72,18 +72,18 @@ Localization
 
 		#autoLOC_500511  = FV-12-25-08 Rockomax Adapter            // C7 Brand Adapter - 2.5m to 1.25m
 		#autoLOC_500514  = FV-12-25-08 Rockomax Adapter (Slanted)  // C7 Brand Adapter Slanted - 2.5m to 1.25m
-		#autoLOC_8310093 = FW-18-25-12 Rockomax Adapter            // FL-A215 Fuel Tank Adapter
+		#autoLOC_8310093 = FV-18-25-12 Rockomax Adapter            // FL-A215 Fuel Tank Adapter
 
-		#autoLOC_500547  = FL-25-08 Rockomax Fuel Tank             // Rockomax X200-8 Fuel Tank
-		#autoLOC_500541  = FL-25-16 Rockomax Fuel Tank             // Rockomax X200-16 Fuel Tank
-		#autoLOC_500544  = FL-25-32 Rockomax Fuel Tank             // Rockomax X200-32 Fuel Tank
-		#autoLOC_500520  = FL-25-64 Rockomax "Jumbo" Fuel Tank     // Rockomax Jumbo-64 Fuel Tank
+		#autoLOC_500547  = FL-25-800 Rockomax Fuel Tank             // Rockomax X200-8 Fuel Tank
+		#autoLOC_500541  = FL-25-k02 Rockomax Fuel Tank             // Rockomax X200-16 Fuel Tank
+		#autoLOC_500544  = FL-25-k03 Rockomax Fuel Tank             // Rockomax X200-32 Fuel Tank
+		#autoLOC_500520  = FL-25-k06 Rockomax "Jumbo" Fuel Tank     // Rockomax Jumbo-64 Fuel Tank
 
 		#autoLOC_500742 =  FV-25-37-030 Kerbodyne Adapter Tank         // Kerbodyne ADTP-2-3
 
-		#autoLOC_500619  = FL-37-072 Kerbodyne Fuel Tank          			// Kerbodyne S3-7200 Tank
-		#autoLOC_500622  = FL-37-036 Kerbodyne Fuel Tank          			// Kerbodyne S3-3600 Tank
-		#autoLOC_500616  = FL-37-144 Kerbodyne Fuel Tank          			// Kerbodyne S3-14400 Tank
+		#autoLOC_500619  = FL-37-k07 Kerbodyne Fuel Tank          			// Kerbodyne S3-7200 Tank
+		#autoLOC_500622  = FL-37-k04 Kerbodyne Fuel Tank          			// Kerbodyne S3-3600 Tank
+		#autoLOC_500616  = FL-37-k14 Kerbodyne Fuel Tank          			// Kerbodyne S3-14400 Tank
 		#autoLOC_8310111 = FL-37-50-064 Kerbodyne Adapter Tank    			// Kerbodyne S3-S4 Adapter Tank
 		#autoLOC_8310117 = FL-50-064 Kerbodyne Fuel Tank          			// Kerbodyne S4-64 Fuel Tank
 		#autoLOC_8310120 = FL-50-128 Kerbodyne Fuel Tank          			// Kerbodyne S4-128 Fuel Tank
@@ -118,8 +118,8 @@ Localization
 		#autoLOC_500598 = Mk3 Monopropellant Fuselage-A        // Mk3 Monopropellant Tank
 
 		#autoLOC_500631 = PB-R04 Xenon Container    // PB-X50R
-		#autoLOC_500625 = PB-06-X07 Xenon Container // PB-X150 Xenon Container
-		#autoLOC_500628 = PB-12-X06 Xenon Container // PB-X750 Xenon Container
+		#autoLOC_500625 = PB-06-07 Xenon Container // PB-X150 Xenon Container
+		#autoLOC_500628 = PB-12-06 Xenon Container // PB-X750 Xenon Container
 
 		#autoLOC_8310074 = Stratus-V1 Minified Monopropellant Tank      // Stratus-V Minified Monopropellant Tank
 		#autoLOC_500610  = Stratus-V3 Roundified Monopropellant Tank    // Stratus-V Roundified Monopropellant Tank

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
@@ -8,7 +8,7 @@
 @PART[ReleaseValve]                { @description ^= :FTE:AFV:           }
 
 @PART[rcsTankMini]                 { @description ^= :FL-R10:FL-R06-20:  }
-@PART[Rockomax16_BW,Rockomax32_BW] { @description ^= :X200-32:FX-32:     }
+@PART[Rockomax16_BW,Rockomax32_BW] { @description ^= :X200-32:FL-25-32:  }
 @PART[Size3LargeTank]              { @description ^= :S3-7200:S3-072:    }
 @PART[Size3LargeTank]              { @description ^= :S3-14400:S3-144:   }                                   
 @PART[xenonTankRadial]             { @description ^= :The X50R:PB-R04:   }
@@ -45,5 +45,6 @@
 
 @PART[fuelTankSmallFlat]                  { @description ^= :T100:FL-12-100:  }  // FL-T100
 @PART[fuelTankSmallFlat,fuelTankSmall]    { @description ^= :T200:FL-12-200:  }  // FL-T100, FL-200
-@PART[fuelTank_long]                      { @description ^= :T400:FL-12-400:  }  // FL-T800
-@PART[fuelTank_long]                      { @description ^= :T800:FL-12-800:  }  // FL-T800
+@PART[fuelTank_long]                      { @description ^= :FL-T400:FL-12-400:  }  // FL-T800
+@PART[fuelTank_long]                      { @description ^= :FL-T800:FL-12-800:  }  // FL-T800
+@PART[rcsTankMini]                        { @description ^= :FL-R20:FL-R06-20: }   // FL-R06

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
@@ -42,3 +42,8 @@
 @PART[parachuteLarge]       { @description ^= :Mk16-XL:Nk-12:              } // Mk16-XL
 @PART[parachuteLarge]       { @description ^= :Mk16:Nk-06:                 } // Mk16-XL
 @PART[parachuteDrogue]      { @description ^= :Mk25:Nk-12D:                } // Mk25
+
+@PART[fuelTankSmallFlat]                  { @description ^= :T100:FL-12-100:  }  // FL-T100
+@PART[fuelTankSmallFlat,fuelTankSmall]    { @description ^= :T200:FL-12-200:  }  // FL-T100, FL-200
+@PART[fuelTank_long]                      { @description ^= :T400:FL-12-400:  }  // FL-T800
+@PART[fuelTank_long]                      { @description ^= :T800:FL-12-800:  }  // FL-T800

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
@@ -1,8 +1,8 @@
 // replacing changed titles in the descriptions
 // 2021-02-28
 
- 
-@PART[seatExternalCmd]             { @description ^= :EAS-1:AAS-1:       }
+
+@PART[seatExternalCmd]             { @description ^= :EAS-1:AAS-1: }
                                                                
 @PART[ReleaseValve,fuelLine]       { @description ^= :FTX:AFD:           }
 @PART[ReleaseValve]                { @description ^= :FTE:AFV:           }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock_patch_desc.cfg
@@ -7,11 +7,11 @@
 @PART[ReleaseValve,fuelLine]       { @description ^= :FTX:AFD:           }
 @PART[ReleaseValve]                { @description ^= :FTE:AFV:           }
 
-@PART[rcsTankMini]                 { @description ^= :FL-R10:FL-R06-20:  }
+@PART[rcsTankMini]                 { @description ^= :FL-R10:OL-06-020:  }
 @PART[Rockomax16_BW,Rockomax32_BW] { @description ^= :X200-32:FL-25-32:  }
-@PART[Size3LargeTank]              { @description ^= :S3-7200:S3-072:    }
-@PART[Size3LargeTank]              { @description ^= :S3-14400:S3-144:   }                                   
-@PART[xenonTankRadial]             { @description ^= :The X50R:PB-R04:   }
+@PART[Size3LargeTank]              { @description ^= :S3-7200:37-k07:    }
+@PART[Size3LargeTank]              { @description ^= :S3-14400:37-k14:   }                                   
+@PART[xenonTankRadial]             { @description ^= :The X50R:Xe-R-04:   }
                                    
 @PART[nuclearEngine]               { @description ^= :LV-N:LV-N1:        }
 @PART[solidBooster_v2]             { @description ^= :RT-10:Hammer:      }
@@ -47,4 +47,4 @@
 @PART[fuelTankSmallFlat,fuelTankSmall]    { @description ^= :T200:FL-12-200:  }  // FL-T100, FL-200
 @PART[fuelTank_long]                      { @description ^= :FL-T400:FL-12-400:  }  // FL-T800
 @PART[fuelTank_long]                      { @description ^= :FL-T800:FL-12-800:  }  // FL-T800
-@PART[rcsTankMini]                        { @description ^= :FL-R20:FL-R06-20: }   // FL-R06
+@PART[rcsTankMini]                        { @description ^= :FL-R20:OL-06-020: }   // FL-R06

--- a/Naming-Spec.md
+++ b/Naming-Spec.md
@@ -1,0 +1,77 @@
+# Prefixes in Use
+
+## General Notes
+
+### Diameters
+
+Sizes are given in decimters; therefore, 2.5m diameter is given as *25*. 10m is
+given as *A0*, which is 100 in hexadecimal. Radial mounts are given a
+"diameter" of *R*.
+
+Typical sizes thus are given as *03*, *06*, *12*, *18*, *25*, *37*, *50*, *75*,
+*A0*.
+
+Parts intended for use in airplanes are sometimes denoted as *Mk0*, *Mk1*,
+*Mk2*, or *Mk3*.
+
+*Kerbodyne S3* is *37*, *Kerbodyne S4* is *50*.
+
+If an item is two different sizes at the two ends, typically both sizes are
+given, e.g. *12-25*. If an adapter has several mounting plates on one end, the
+count of these plates is also provided; e.g. *37-25x4*.
+
+### Magnitude
+
+For volumes and ranges, a prefix of *k* means that the given number is in
+thousands, and a prefix of *m* means the given number is in millions.
+
+### Source Designation
+
+For commonly-provided parts (such as fuel tanks), often an abbreviation for the
+source mod will be added after the part title, in parenthesis; e.g. *(RS+)*.
+
+(Selected) designations thus used:
+
+- FTP -- Fuel Tanks Plus
+- Kerbonov
+- N-Series -- Near Future Launch Vehicles
+- Orion -- Stockish Project Orion
+- SpaceY
+- SR -- USI Sounding Rockets
+- SSR -- MicroSat
+- RLA -- RLA Reborn
+- RS+ -- ReStock Plus
+
+## Pods
+
+*RC* is used as a prefix for probe cores.
+
+## Engines
+
+Engines have yet to be thoroughly standardized and thus still use a variety of
+naming conventions.
+
+If in doubt, you can use the *LV* ("Liquid Vector") for liquid fuel + oxidizer
+engines, *O* (the letter after *N*, rather than the number) for monopropellant
+engines, and *J* for jet engines.
+
+The exception is solid rocket boosters, that are named "SRB-*diameter*-*fuel
+amount*.
+
+## Tanks
+
+Tanks are named "*prefix*-*diameter*-*volume* 'nice' name".
+
+(Selected) prefixes used:
+
+    - FL ("Fuel Level") -- regular liquid fuel + oxidizer tanks
+    - FS -- single-ended liquid fuel + oxidizer tanks
+    - FV -- adapter liquid fuel + oxidizer tanks; i.e. tanks that have different
+      diameters top and bottom
+    - OL -- for monopropellant tanks
+    - Ar -- for Argon tanks
+    - Li -- for Lithium tanks
+    - Xe -- for Xenon tanks
+    - UH -- Holding tanks (for Ore)
+    - NL ("Nuclear Liquid") -- liquid fuel only tanks, for use with Nuclear engines
+    - YD -- Hydrogen Tanks


### PR DESCRIPTION
Renames the stock tanks to a consistent scheme across sizes:

>  FL - \<tank diameter\> - \<tank volume\>  \<nice name\>

*FL* is used for liquid fuel tanks, *FS* for nose cones (and other single ended tanks), *FV* for adapter tanks (tanks whose two ends are different sizes).

The first letter changes if the tank carries something else, e.g. *NL* tanks carry nuclear fuel.

Remains a Work in Progress, is incomplete, and is currently untested.