### PR TITLE
Stock tanks 2

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
@@ -103,35 +103,35 @@ Localization
 
 		// 7.5 Metre
 		// ======
-		#LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (N-Series)  // R-EX Guidance Computer Unit
+		#LOC_NFLaunchVehicles_nflv-drone-75-1_title               = RC-75 Guidance Computer Unit (E-Series)  // R-EX Guidance Computer Unit
 		#LOC_NFLaunchVehicles_nflv-battery-75-1_title             = Zs-75-72K Rechargeable Battery Bank      // Z-72K Rechargeable Battery Bank
-		#LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (N-Series)               // TD-750 Stack Decoupler
-		#LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (N-Series)               // TS-750 Stack Separator
-		#LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m) (N-Series) // AE-FF5 Payload Fairing (7.5m)
+		#LOC_NFLaunchVehicles_nflv-decoupler-75-1_title           = TD-75 Decoupler (E-Series)               // TD-750 Stack Decoupler
+		#LOC_NFLaunchVehicles_nflv-separator-75-1_title           = TS-75 Separator (E-Series)               // TS-750 Stack Separator
+		#LOC_NFLaunchVehicles_nflv-fairing-75-1_title             = AE-FF5 Payload Fairing (7.5m) (E-Series) // AE-FF5 Payload Fairing (7.5m)
 
-		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = FV-50-75-k12 "SKL" Adapter Tank (N-Series)             // EA-AD-SKL Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = FV-50-75-k12 Adapter Tank (N-Series)  // EA-S10 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = FV-50-75-k23 Adapter Tank (N-Series)  // EA-S20 Fuel Tank Adapter
-		#LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = FS-75-k022 Rounded Nosecone (N-Series)           // EA-C-64 Rounded Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = FS-75-k043 Fuelled Nosecone (N-Series)           // EA-C-128 Fuelled Nosecone
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = FL-75-k014 Fuel Tank (N-Series)       // EA-F96 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = FL-75-k029 Fuel Tank (N-Series)       // EA-F192 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = FL-75-k058 Fuel Tank (N-Series)       // EA-F384 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = FL-75-k115 Fuel Tank (N-Series)       // EA-F768 Fuel Tank
-		#LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = FL-75-k230 Fuel Tank (N-Series)       // EA-F1536 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-skeletal-adapter-75-5-1_title  = FV-50-75-k12 "SKL" Adapter Tank (E-Series)             // EA-AD-SKL Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-75-5-2_title           = FV-50-75-k12 Adapter Tank (E-Series)  // EA-S10 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-adapter-75-5-1_title           = FV-50-75-k23 Adapter Tank (E-Series)  // EA-S20 Fuel Tank Adapter
+		#LOC_NFLaunchVehicles_nflv-fueltank-round-75-1_title      = FS-75-k022 Rounded Nosecone (E-Series)           // EA-C-64 Rounded Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-nosecone-75-1_title   = FS-75-k043 Fuelled Nosecone (E-Series)           // EA-C-128 Fuelled Nosecone
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-4_title            = FL-75-k014 Fuel Tank (E-Series)       // EA-F96 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-3_title            = FL-75-k029 Fuel Tank (E-Series)       // EA-F192 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-2_title            = FL-75-k058 Fuel Tank (E-Series)       // EA-F384 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-1_title            = FL-75-k115 Fuel Tank (E-Series)       // EA-F768 Fuel Tank
+		#LOC_NFLaunchVehicles_nflv-fueltank-75-5_title            = FL-75-k230 Fuel Tank (E-Series)       // EA-F1536 Fuel Tank
 
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-1_title = Adapter 75-L1 Lower Stage Engine Mount      // ER-L1 Lower Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-lower-75-2_title = Adapter 75-L2 Lower Stage Engine Mount      // ER-L2 Lower Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-1_title = Adapter 75-U1 Upper Stage Engine Mount      // ER-U1 Upper Stage Engine Mount
 		#LOC_NFLaunchVehicles_nflv-cluster-mount-upper-75-2_title = Adapter 75-U2 Upper Stage Engine Mount      // ER-U2 Upper Stage Engine Mount
 
-		#LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (N-Series)  // E-Series Structural Tube
-		#LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (N-Series)                  // E-Series Service Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (N-Series)                  // ECR-8 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (N-Series)                  // ECR-4 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (N-Series)                  // ECR-2 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (N-Series)                  // ECR-1 Cargo Bay
-		#LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (N-Series)             // ECR-N Nose Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-tube-75-1_title          = N75 Structural Decouplable Tube (E-Series)  // E-Series Structural Tube
+		#LOC_NFLaunchVehicles_nflv-service-bay-75-1_title         = N75 Service Bay (E-Series)                  // E-Series Service Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-1_title               = N75-8 Cargo Bay (E-Series)                  // ECR-8 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-2_title               = N75-4 Cargo Bay (E-Series)                  // ECR-4 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-3_title               = N75-2 Cargo Bay (E-Series)                  // ECR-2 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-75-4_title               = N75-1 Cargo Bay (E-Series)                  // ECR-1 Cargo Bay
+		#LOC_NFLaunchVehicles_nflv-cargo-nose-75-1_title          = N75-N Nose Cargo Bay (E-Series)             // ECR-N Nose Cargo Bay
 
 
 		// Support

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
@@ -78,7 +78,7 @@ Localization
 		#LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title        = FL-37-900 Hemispherical Fuel Tank (RS+) // Kerbodyne S3-1800R Hemispherical Liquid Fuel Tank
 		#LOC_RestockPlus_restock-nosecone-375-1_title                = FL-37-k04 Nosecone (RS+)                // Kerbodyne S3-3600 Nosecone
 		#LOC_RestockPlus_restock-fuel-tank-375-4_title               = FL-37-k02 Fuel Tank (RS+)               // Kerbodyne S3-1800 Tank
-		#LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_title     = XX FL-37 S3-S4-054 Adapter Tank (RS+)         // Kerbodyne SAIV Liquid Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-375-5-1_title     = FV-37-50-k06 Adapter Fuel Tank (RS+)    // Kerbodyne SAIV Liquid Fuel Tank Adapter
 		#LOC_RestockPlus_restock-fuel-tank-saturn-engine-1_title     = FV-50-k09 Fuelled Engine Adapter (RS+)  // Kerbodyne SIV Fuelled Engine Adapter
 		#LOC_RestockPlus_restock-fuel-tank-5-1_title                 = FL-50-k51 Fuel Tank (RS+)               // Kerbodyne SIV-512K Liquid Fuel Tank
 		#LOC_RestockPlus_restock-fuel-tank-5-2_title                 = FL-50-k26 Fuel Tank (RS+)               // Kerbodyne SIV-256K Liquid Fuel Tank

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
@@ -20,7 +20,7 @@ Localization
 		
 		#LOC_RestockPlus_restock-mk2-pod_title = Mk1-18 'Acorn' Command Pod
 		
-	    #LOC_RestockPlus_restock-pod-sphere-1_title = KP-1 'Clementine' Reentry Module  // SP-1 'Clementine' Reentry Module
+		#LOC_RestockPlus_restock-pod-sphere-1_title = KP-1 'Clementine' Reentry Module  // SP-1 'Clementine' Reentry Module
 		#LOC_RestockPlus_restock-pod-sphere-2_title = KP-2 'Tangerine' Reentry Module   // SP-2 'Tangerine' Reentry Module
 		#LOC_RestockPlus_restock-pod-sphere-3_title = KP-3 'Mandarin' Reentry Module    // SP-3 'Mandarin' Reentry Module
 
@@ -73,7 +73,7 @@ Localization
 		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-1_title  = FV-12-18-C-600 Adapter Fuel Tank (Long) (RS+)   // FL-XA600 Fuel Tank Adapter
 		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-125-2_title  = FV-12-18-A-160 Adapter Fuel Tank (Short) (RS+)  // FL-XA160 Fuel Tank Adapter
 		#LOC_RestockPlus_restock-fuel-tank-adapter-1875-0625-1_title = FV-06-18-160 Adapter Fuel Tank (RS+)            // FL-XA160-S Fuel Tank Adapter
-		#LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_title   = FV-18-25-k1 Rockomax Adapter Fuel Tank (RS+)   // FL-XA1200 Fuel Tank Adapter
+		#LOC_RestockPlus_restock-fuel-tank-adapter-25-1875-1_title   = FV-18-25-k1 Rockomax Adapter Fuel Tank (RS+)    // FL-XA1200 Fuel Tank Adapter
 
 		#LOC_RestockPlus_restock-fuel-tank-sphere-375-1_title        = FL-37-900 Hemispherical Fuel Tank (RS+) // Kerbodyne S3-1800R Hemispherical Liquid Fuel Tank
 		#LOC_RestockPlus_restock-nosecone-375-1_title                = FL-37-k04 Nosecone (RS+)                // Kerbodyne S3-3600 Nosecone

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
@@ -7,29 +7,29 @@
 
 Localization
 {
-	en-us
-	{
-		#LOC_SSR_MicroSat_title             = RC-0 MicroSat (SSR)                               // SSR MicroSat
+    en-us
+    {
+        #LOC_SSR_MicroSat_title             = RC-0 MicroSat (SSR)                               // SSR MicroSat
 
         #LOC_SSR_microXenon_title           = Xe-03-24 Octagonal Xenon Container (Micro)        // SSR Micro Xenon Container
         #LOC_SSR_radialXenonmicro_title     = Xe-R-015 Radial Xenon Container (Micro)           // SSR Micro Radial Xenon Container
-		#LOC_SSR_625liquidFuel_title        = FL-06-080 Fuel Tank (SSR)                         // 0.625m Fuel Tank
-		#LOC_SSR_microlqdfuel_title         = FL-03-14 MicroSat Liquid Fuel Tank (SSR)          // SSR MicroSat Liquid Fuel Tank
+        #LOC_SSR_625liquidFuel_title        = FL-06-080 Fuel Tank (SSR)                         // 0.625m Fuel Tank
+        #LOC_SSR_microlqdfuel_title         = FL-03-14 MicroSat Liquid Fuel Tank (SSR)          // SSR MicroSat Liquid Fuel Tank
         
-		#LOC_SSR_microsatEngine_title       = LV-0-4 Microsat Liquid Fuel Engine (SSR) 			// SSR Microsat Liquid Fuel Engine
+        #LOC_SSR_microsatEngine_title       = LV-0-4 Microsat Liquid Fuel Engine (SSR) 			// SSR Microsat Liquid Fuel Engine
         #LOC_SSR_solidBoosterMini_title     = SRB-06-06 "Thumper" MiniRocket (SSR)              // SRB625 "Thumper" MiniRocket
         #LOC_SSR_upperStageEngine_title     = 31-8V "Bambi" Liquid Fuel Engine (SSR)            // SSR US01 "Bambi" Liquid Fuel Engine		
         #LOC_SSR_microIon_title             = IX-2526 "Atom" MicroIonic Propulsion System (SSR) // SSR "Atom" MicroIonic Propulsion System
         
-		#LOC_SSR_35decoupler_title          = TD-03 Squarified to Octagonal Decoupler (SSR)     // SSR Squarified to Octagonal Adaptive Decoupler
+        #LOC_SSR_35decoupler_title          = TD-03 Squarified to Octagonal Decoupler (SSR)     // SSR Squarified to Octagonal Adaptive Decoupler
         #LOC_SSR_625decoupler_title         = TD-06 Decoupler (SSR)		                        // 0.625m Decoupler
 
         // #LOC_SSR_fairingSize0_title         = AE-FF0 SSR Fairing                                // AE-FF0 Airstream Protective Shell (0.625m)
         
-		#LOC_SSR_microSolarUnshielded_title = OX 1x4 Photovoltaic Panels (SSR)                  // SSR Micro Solar Array
+        #LOC_SSR_microSolarUnshielded_title = OX 1x4 Photovoltaic Panels (SSR)                  // SSR Micro Solar Array
         #LOC_SSR_micrortg_title             = U-NUK Squarified MicroRTG (SSR)                   // SSR MicroRTG
-		#LOC_SSR_MICROBATSQUARE_title       = Z-060 "MB-45" Squarified Battery (SSR)            // SSR MB-45 Battery
-		
+        #LOC_SSR_MICROBATSQUARE_title       = Z-060 "MB-45" Squarified Battery (SSR)            // SSR MB-45 Battery
+        
         #LOC_SSR_foldedDipole_title         = C0 Folded Dipole Antenna (SSR)                    // Folded Dipole Antenna
         #LOC_SSR_foldingDish01_title        = C1 DTS Antenna (SSR)                              // DTS-01 Antenna
         #LOC_SSR_FixedDish01_title          = C2 Smallified Dish Antenna (SSR)                  // FD-01 Smallified Dish Antenna

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SquiggsySpaceResearch.cfg
@@ -40,5 +40,5 @@ Localization
 }
 
 // Conditional Parts included with the mod
-@PART[microArgon]:NEEDS[SquiggsySpaceResearch,NearFuturePropulsion]:AFTER[SquiggsySpaceResearch] { @title = Ar-03-k4 Octagonal Argon Container (Micro)  }    // Micro Argon Container
-@PART[microCapacitor]:NEEDS[SquiggsySpaceResearch,NearFutureElectrical]:AFTER[SquiggsySpaceResearch] { @title = ZZ-200 Micro Capacitor (SSR) }               // Micro Capacitor
+@PART[microArgon]:NEEDS[NearFuturePropulsion]:AFTER[SquiggsySpaceResearch]      { @title = Ar-03-k4 Octagonal Argon Container (Micro)   }  // Micro Argon Container
+@PART[microCapacitor]:NEEDS[NearFutureElectrical]:AFTER[SquiggsySpaceResearch]  { @title = ZZ-200 Micro Capacitor (SSR)                 }  // Micro Capacitor


### PR DESCRIPTION
Per comments on #17.

"This PR is just a couple of cleanup things: 'E-Series' for the Near Future 7.5m tanks, drop the 'XX' prefix, and clean up the SSR MircoSat conditional name patches."