### PR TITLE
[RV, RL] rework RCS blocks

### DIFF
--- a/GameData/002_CommunityPartsTitles/Localization/CPT_Kerbonov_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_Kerbonov_patch.cfg
@@ -16,8 +16,8 @@
 @PART[fuelTank_extralong]:NEEDS[Kerbonov]     {@title = FL-12-k2 Fuel Tank (Kerbonov)                    }  //  FL-T1600 Fuel Tank
 @PART[fuelTank4-0]:NEEDS[Kerbonov]            {@title = FL-25-400 Rockomax Fuel Tank (Kerbonov)                        }  //  Rockomax X200-4 Fuel Tank
 
-@PART[ProbeRCSBlock]:NEEDS[Kerbonov]          {@title = RV-030 Self-Contained Probe RCS                 }  //  Self-Contained Probe RCS
-@PART[ModifiedProbeRCSBlock]:NEEDS[Kerbonov]  {@title = RV-030 Self-Contained Probe RCS (45°)           }  //  Modified Self-Contained Probe RCS
+@PART[ProbeRCSBlock]:NEEDS[Kerbonov]          {@title = RV-034 Self-Contained Probe RCS                 }  //  Self-Contained Probe RCS
+@PART[ModifiedProbeRCSBlock]:NEEDS[Kerbonov]  {@title = RV-034-A Self-Contained Probe RCS (45°)           }  //  Modified Self-Contained Probe RCS
 
 @PART[radialmicrodecoupler]:NEEDS[Kerbonov]   {@title = TT-08 Radial Micro Decoupler                    }  //  Radial Micro Decoupler
 

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_Luciole_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_Luciole_loc.cfg
@@ -30,7 +30,7 @@
 		#LOC_Luciole_Luciole_NoseCone_03125_title   = AN-03 "Baby Locust" Nose Cone (Luciole)  // L-NS "BabyLocust" Nose Cone
 		#LOC_Luciole_Luciole_NoseCone_0625_title    = AN-06 "Locust" Nose Cone (Luciole)  // L-N "Locust" Nose Cone
 		
-		#LOC_Luciole_Luciole_RCS_A_srf_title        = RV-150 "Pondskater" RCS Block (Luciole)  // L-R "Pondskater" RCS
+		#LOC_Luciole_Luciole_RCS_A_srf_title        = RV-014-H "Pondskater" Tiny RCS Block (Luciole)  // L-R "Pondskater" RCS
 
 		#LOC_Luciole_Luciole_iodine_engine_title    = IX-30 "Weevils" Ion Engine (Luciole)  // LPT-30 "Weevils" Ion Engine
 

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_MandatoryRCSPartPack_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_MandatoryRCSPartPack_patch.cfg
@@ -3,17 +3,17 @@
 
 
 
-@PART[RCS_025T_1xfront]:NEEDS[MandatoryRCSPartPack]              {@title = RM-025x1 Linear RCS Port              } // RM-025-O Micro RCS Block
-@PART[RCS_025T_1xdown]:NEEDS[MandatoryRCSPartPack]               {@title = RM-025x1 Micro RCS Block              } // RM-025-L Micro RCS Block
-@PART[RCS_025T_2xlateral]:NEEDS[MandatoryRCSPartPack]            {@title = RM-025x2 Micro RCS Block              } // RM-025-I Micro RCS Block
-@PART[RCS_025T_2xlateral45]:NEEDS[MandatoryRCSPartPack]          {@title = RM-025x2-A Micro RCS Block (45°)      } // RM-025-IV Micro RCS Block
-@PART[RCS_025T_2xlateral_1xdown]:NEEDS[MandatoryRCSPartPack]     {@title = RM-025x3 Micro RCS Block              } // RM-025-IL Micro RCS Block
-@PART[RCS_025T_2xlateral45_1xdown]:NEEDS[MandatoryRCSPartPack]   {@title = RM-025x3-A Micro RCS Block (45°)      } // RM-025-IVL Micro RCS Block
+@PART[RCS_025T_1xfront]:NEEDS[MandatoryRCSPartPack]              {@title = RV-031 Linear RCS Port              } // RM-025-O Micro RCS Block
+@PART[RCS_025T_1xdown]:NEEDS[MandatoryRCSPartPack]               {@title = RV-031-A Micro RCS Block              } // RM-025-L Micro RCS Block
+@PART[RCS_025T_2xlateral]:NEEDS[MandatoryRCSPartPack]            {@title = RV-032 Micro RCS Block              } // RM-025-I Micro RCS Block
+@PART[RCS_025T_2xlateral45]:NEEDS[MandatoryRCSPartPack]          {@title = RV-032-A Micro RCS Block (45°)      } // RM-025-IV Micro RCS Block
+@PART[RCS_025T_2xlateral_1xdown]:NEEDS[MandatoryRCSPartPack]     {@title = RV-033 Micro RCS Block              } // RM-025-IL Micro RCS Block
+@PART[RCS_025T_2xlateral45_1xdown]:NEEDS[MandatoryRCSPartPack]   {@title = RV-033-A Micro RCS Block (45°)      } // RM-025-IVL Micro RCS Block
 
-@PART[RV105_1xdown]:NEEDS[MandatoryRCSPartPack]                  {@title = RV-105x1 RCS Thruster Block           } // RV-105-L RCS Thruster Block
-@PART[RV105_2xlateral]:NEEDS[MandatoryRCSPartPack]               {@title = RV-105x2 RCS Thruster Block           } // RV-105-I RCS Thruster Block
-@PART[RV105_2xlateral45]:NEEDS[MandatoryRCSPartPack]             {@title = RV-105x2-A RCS Thruster Block (45°)   } // RV-105-IV RCS Thruster Block
-@PART[RV105_2xlateral_1xdown]:NEEDS[MandatoryRCSPartPack]        {@title = RV-105x3 RCS Thruster Block           } // RV-105-IL RCS Thruster Block
-@PART[RV105_2xlateral45_1xdown]:NEEDS[MandatoryRCSPartPack]      {@title = RV-105x3-A RCS Thruster Block (45°)   } // RV-105-IVL RCS Thruster Block
-@PART[RV105_2xlateral45_1xup_1xdown]:NEEDS[MandatoryRCSPartPack] {@title = RV-105x4-A RCS Thruster Block (45°)   } // RV-105-IVL2 RCS Thruster Block
-@PART[RV105_2xlateral_2xfront]:NEEDS[MandatoryRCSPartPack]       {@title = RV-105x4-B RCS Thruster Block (90°)   } // RV-105-IO2 RCS Thruster Block
+@PART[RV105_1xdown]:NEEDS[MandatoryRCSPartPack]                  {@title = RV-101 RCS Thruster Block           } // RV-105-L RCS Thruster Block
+@PART[RV105_2xlateral]:NEEDS[MandatoryRCSPartPack]               {@title = RV-102 RCS Thruster Block           } // RV-105-I RCS Thruster Block
+@PART[RV105_2xlateral45]:NEEDS[MandatoryRCSPartPack]             {@title = RV-102-A RCS Thruster Block (45°)   } // RV-105-IV RCS Thruster Block
+@PART[RV105_2xlateral_1xdown]:NEEDS[MandatoryRCSPartPack]        {@title = RV-103 RCS Thruster Block           } // RV-105-IL RCS Thruster Block
+@PART[RV105_2xlateral45_1xdown]:NEEDS[MandatoryRCSPartPack]      {@title = RV-103-A RCS Thruster Block (45°)   } // RV-105-IVL RCS Thruster Block
+@PART[RV105_2xlateral45_1xup_1xdown]:NEEDS[MandatoryRCSPartPack] {@title = RV-104-A RCS Thruster Block (45°)   } // RV-105-IVL2 RCS Thruster Block
+@PART[RV105_2xlateral_2xfront]:NEEDS[MandatoryRCSPartPack]       {@title = RV-104-B RCS Thruster Block (90°)   } // RV-105-IO2 RCS Thruster Block

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_Mk2Expansion_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_Mk2Expansion_loc.cfg
@@ -112,10 +112,10 @@ Localization
 
 		// Utility
 		#LOC_M2X_ACSBlister_title = Mk2 ACS Blister					// Configurable ACS Blister
-		#LOC_M2X_OMSCluster_title = Mk2 OMS Blister					// Configurable OMS Blister (4 variants)
-		#LOC_M2X_RCSCluster_title = Mk2 RCS Blister					// RCS Blister (4 variants)
-		#LOC_M2X_FF5_title        = Mk2 RCS Block (5-Way)			// 5-Way Mk2 RCS Block
-		#LOC_M2X_RCSChine_title   = Mk2 RCS Chine					// Configurable RCS Chine
+		#LOC_M2X_OMSCluster_title = RL-805 OMS Blister (Mk2+)	 				// Configurable OMS Blister (4 variants)
+		#LOC_M2X_RCSCluster_title = RV-105 RCS Blister (Mk2+)					// RCS Blister (4 variants)
+		#LOC_M2X_FF5_title        = RV-105 RCS Block (5-Way) (Mk2+)			// 5-Way Mk2 RCS Block
+		#LOC_M2X_RCSChine_title   = RV-205 RCS Chine (Mk2+)					// Configurable RCS Chine
 
 		#LOC_M2X_Cblock_title     = Chine Mk2 RCS (Segment)         // RC RCS Chine segment
 		#LOC_M2X_Eblock_title     = Chine Mk2 RCS (Cap)             // PG RCS Chine Cap

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_Mk3Expansion_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_Mk3Expansion_loc.cfg
@@ -105,11 +105,11 @@ Localization
 
 		// Control
 
-		#LOC_M3X_RCSBlock_Name			= Mk3 RCS Block (5-Way)				// 5-Way Mk3 RCS Block
-		#LOC_M3X_ChineRCS_Name			= Mk3 RCS Chine (Segment)			// Mk3 RCS Chine Segment
-		#LOC_M3X_ChineRCSEnd_Name		= Mk3 RCS Chine (Cap)				// Mk3 RCS Chine Cap
-		#LOC_M3X_SaddleTankRCS_Name		= Mk3-S RCS Saddletank (Segment)	// Mk3 RCS Saddletank
-		#LOC_M3X_SaddleTankRCSCap_Name	= Mk3-S RCS Saddletank (Cap)		// Mk3 Saddletank RCS Cap
+		#LOC_M3X_RCSBlock_Name			= RVa-125 Heavy RCS Block (5-Way) (Mk3+)			// 5-Way Mk3 RCS Block
+		#LOC_M3X_ChineRCS_Name			= RV-602 RCS Chine Segment (Mk3+)			// Mk3 RCS Chine Segment
+		#LOC_M3X_ChineRCSEnd_Name		= RV-605 RCS Chine Cap (Mk3+)				// Mk3 RCS Chine Cap
+		#LOC_M3X_SaddleTankRCS_Name		= RV-603 RCS Saddletank Segment (Mk3+)	// Mk3 RCS Saddletank
+		#LOC_M3X_SaddleTankRCSCap_Name	= RV-603 RCS Saddletank Cap (Mk3+)		// Mk3 Saddletank RCS Cap
 		
 		#LOC_M3X_RCSAS_title			= WR-Mk3 Stability Control Module	// Mk3 Reaction Wheel Assembly
 

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureAeronautics_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureAeronautics_loc.cfg
@@ -57,7 +57,7 @@ Localization
 
 
 		// RCS
-		#LOC_NearFutureAero_rcsblister-1_title =  RXH-4x4-M Angled Aeronautic Heavy RCS Blister  // ARV-100-8 Heavy RCS Blister
+		#LOC_NearFutureAero_rcsblister-1_title =  RV-404 Angled Aeronautic Heavy RCS Blister  // ARV-100-8 Heavy RCS Blister
 
 	}
 }

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_NearFutureSpacecraft_LaunchVehicles_loc.cfg
@@ -158,17 +158,17 @@ Localization
 
 		// RCS
 		// ======
-		#LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-1_title             = RX-5x1 Heavy RCS Thruster                           // RQ-5x1 Heavy RCS Thruster
-		#LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-1_title             = RX-5x4 Heavy RCS Block                              // RQ-5x4 Heavy RCS Block
-		#LOC_NFLaunchVehicles_nflv-rcs-aero-heavy-1_title           = RX-5x4-A Aerodynamic Heavy RCS Block                // RQ-5-A Aerodynamic Heavy RCS Block
+		#LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-1_title             = RV-991 Heavy RCS Linear Thruster                           // RQ-5x1 Heavy RCS Thruster
+		#LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-1_title             = RV-994 Heavy RCS Block                              // RQ-5x4 Heavy RCS Block
+		#LOC_NFLaunchVehicles_nflv-rcs-aero-heavy-1_title           = RV-994-A Aerodynamic Heavy RCS Block                // RQ-5-A Aerodynamic Heavy RCS Block
 
-		#LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-2_title             = RX-88x1 Heavy Bipropellant RCS Thruster             // RJ-88x1 Heavy Bipropellant RCS Thruster
-		#LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-2_title             = RX-88x4 Heavy Bipropellant RCS Block                // RJ-88x4 Heavy Bipropellant RCS Block
-		#LOC_NFLaunchVehicles_nflv-rcs-aero-heavy-2_title           = RX-88x4-A Aerodynamic Heavy Bipropellant RCS Block  // RJ-88-A Aerodynamic Heavy Bipropellant RCS Block
+		#LOC_NFLaunchVehicles_nflv-rcs-heavy-1x-2_title             = RL-801 Heavy Bipropellant RCS Linear Thruster             // RJ-88x1 Heavy Bipropellant RCS Thruster
+		#LOC_NFLaunchVehicles_nflv-rcs-heavy-4x-2_title             = RL-804 Heavy Bipropellant RCS Block                // RJ-88x4 Heavy Bipropellant RCS Block
+		#LOC_NFLaunchVehicles_nflv-rcs-aero-heavy-2_title           = RL-804-A Aerodynamic Heavy Bipropellant RCS Block  // RJ-88-A Aerodynamic Heavy Bipropellant RCS Block
 
-		#LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-1_title        = VS-4 Integrated RCS Block                           // AVCS-4 Integrated RCS Block
-		#LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-2_title        = VS-4A Integrated RCS Block                          // AVCS-4A Integrated RCS Block
-		#LOC_NFLaunchVehicles_nflv-rcs-integrated-3x-1_title        = VS-3 Integrated RCS Block                           // AVCS-3 Integrated RCS Block
+		#LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-1_title        = RL-104 Integrated RCS Block                           // AVCS-4 Integrated RCS Block
+		#LOC_NFLaunchVehicles_nflv-rcs-integrated-4x-2_title        = RL-104-A Integrated RCS Block                          // AVCS-4A Integrated RCS Block
+		#LOC_NFLaunchVehicles_nflv-rcs-integrated-3x-1_title        = RL-103 Integrated RCS Block                           // AVCS-3 Integrated RCS Block
 		#LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-1_title    = VS-LH-4 Integrated RCS Block                        // AVCS-LH-4 Integrated RCS Block
 		#LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-4x-2_title    = VS-LH-4A Integrated RCS Block                       // AVCS-LH-4A Integrated RCS Block
 		#LOC_NFLaunchVehicles_nflv-rcs-integrated-lh2-3x-1_title    = VS-LH-3 Integrated RCS Block                        // AVCS-LH-3 Integrated RCS Block
@@ -230,13 +230,13 @@ Localization
 		#LOC_NFLaunchVehicles_cargo-75-4_title         = N75-1 Cargo Bay (E-Series)
 		#LOC_NFLaunchVehicles_cargo-nose-75-1_title    = N75-N Nose Cargo Bay (E-Series)
 		// Other
-		#LOC_NFSpacecraft_rcsblock-aero-5way-1_title       = RV-075x5 RCS Thruster Block                // RV-105x5 RCS Thruster Block
-		#LOC_NFSpacecraft_rcsblock-orbital-linear-1_title  = RW-1 Linear RCS Thruster                   // RX-1 Linear RCS Thruster
-		#LOC_NFSpacecraft_rcsblock-orbital-2way-45-1_title = RW-15 Bidirectional RCS Thruster Block     // RX-15 Bidirectional RCS Thruster Block
-		#LOC_NFSpacecraft_rcsblock-orbital-2way-45-2_title = RW-30 Bidirectional RCS Thruster Block     // RX-30 Bidirectional RCS Thruster Block
-		#LOC_NFSpacecraft_rcsblock-orbital-3way-1_title    = RW-15T Tridirectional RCS Block            // RX-15T Tridirectional RCS Block
-		#LOC_NFSpacecraft_rcsblock-orbital-4way-1_title    = RW-45 Advanced RCS Block                   // RX-45 Advanced RCS Block
-		#LOC_NFSpacecraft_rcsblock-orbital-5way-1_title    = RW-55 Advanced RCS Block                   // RX-55 Advanced RCS Block
+		#LOC_NFSpacecraft_rcsblock-aero-5way-1_title       = RV-075 RCS Thruster Block                // RV-105x5 RCS Thruster Block
+		#LOC_NFSpacecraft_rcsblock-orbital-linear-1_title  = RV-101-H Linear RCS Thruster                   // RX-1 Linear RCS Thruster
+		#LOC_NFSpacecraft_rcsblock-orbital-2way-45-1_title = RV-102-AH Bidirectional RCS Thruster Block     // RX-15 Bidirectional RCS Thruster Block
+		#LOC_NFSpacecraft_rcsblock-orbital-2way-45-2_title = RV-202-AH Bidirectional RCS Thruster Block     // RX-30 Bidirectional RCS Thruster Block
+		#LOC_NFSpacecraft_rcsblock-orbital-3way-1_title    = RV-103-AH Tridirectional RCS Block            // RX-15T Tridirectional RCS Block
+		#LOC_NFSpacecraft_rcsblock-orbital-4way-1_title    = RV-104-H Advanced RCS Block                   // RX-45 Advanced RCS Block
+		#LOC_NFSpacecraft_rcsblock-orbital-5way-1_title    = RV-105-H Advanced RCS Block                   // RX-55 Advanced RCS Block
 		#LOC_NFLaunchVehicles_rcs-heavy-1way-1_title       = RX-40x1 Heavy RCS Thruster                 // RQ-5x1 Heavy RCS Thruster
 		#LOC_NFLaunchVehicles_rcs-heavy-4way-1_title       = RX-40x4 Heavy RCS Block                    // RQ-5x4 Heavy RCS Block
 		#LOC_NFLaunchVehicles_rcs-aero-heavy-1_title       = RX-40x4-LFO Aerodynamic Heavy RCS Block    // RQ-5A Aerodynamic Heavy RCS Block

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_RLA_Reborn_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_RLA_Reborn_loc.cfg
@@ -68,14 +68,14 @@ Localization
 
 		// Control
 
-		#RLA_rcs_micro_linear_Part_title = RL-025x1 Linear RCS Port             // RM-50 Micro RCS Block
-		#RLA_rcs_micro_Part_title        = RL-025x4 Micro RCS Block             // RM-105 Micro RCS Block
-		#RLA_rcs_micro45_Part_title      = RL-025x4-A Micro RCS Block (45°)     // RM-105-45 Micro RCS Block
-		#RLA_rcs_linear_Part_title       = RV-105x1 Linear RCS Port	            // RV-50 Linear RCS Port
-		#RLA_rcs_2way_Part_title         = RV-105x2 RCS Thruster Block          // RV-80 RCS Thruster Block
-		#RLA_rcs45_2way_Part_title       = RV-105x2-A RCS Thruster Block (45°)  // RV-80-45 RCS Thruster Block
-		#RLA_rcs45_Part_title            = RV-105x4-A RCS Thruster Block (45°)  // RV-105-45 RCS Thruster Block
-		#RLA_rcs_5way_Part_title         = RV-105x5 RCS Thruster Block          // RV-105-PLUS RCS Thruster Block
+		#RLA_rcs_micro_linear_Part_title = RV-031 Linear RCS Port (RLA)             // RM-50 Micro RCS Block
+		#RLA_rcs_micro_Part_title        = RV-034 Micro RCS Block (RLA)             // RM-105 Micro RCS Block
+		#RLA_rcs_micro45_Part_title      = RV-034-A Micro RCS Block (45°) (RLA)     // RM-105-45 Micro RCS Block
+		#RLA_rcs_linear_Part_title       = RV-101 Linear RCS Port (RLA)	            // RV-50 Linear RCS Port
+		#RLA_rcs_2way_Part_title         = RV-102 RCS Thruster Block (RLA)          // RV-80 RCS Thruster Block
+		#RLA_rcs45_2way_Part_title       = RV-102-A RCS Thruster Block (45°) (RLA)  // RV-80-45 RCS Thruster Block
+		#RLA_rcs45_Part_title            = RV-104-A RCS Thruster Block (45°) (RLA)  // RV-105-45 RCS Thruster Block
+		#RLA_rcs_5way_Part_title         = RV-105 RCS Thruster Block (RLA)          // RV-105-PLUS RCS Thruster Block
 
 		#RLA_tiny_torque_radial_Part_title = WR Tiny Reaction Wheel (Radial) (RLA)  // Tiny Radial Reaction Wheel
 

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_ReStockPlus_loc.cfg
@@ -101,7 +101,7 @@ Localization
 		#LOC_RestockPlus_restock-rcs-block-quad-angled-1_title        = RV-105x4-A RCS Thruster Block (45°)  // RV-105-A RCS Thruster Block
 		#LOC_RestockPlus_restock-rcs-block-quint-1_title              = RV-105x5 RCS Thruster Block          // RV-105-X RCS Thruster Block
 
-		#LOC_RestockPlus_restock-rcs-block-multi-mini-2_title         = RV-01X-A RCS Thruster Block (45°)    // RV-1X-A RCS Thruster Block
+		#LOC_RestockPlus_restock-rcs-block-multi-mini-2_title         = RV-014-A RCS Thruster Block (45°)    // RV-1X-A RCS Thruster Block
 		#LOC_RestockPlus_restock-rcs-block-multi-2_title              = RV-105-A RCS Thruster Block (45°)    // RV-105-A RCS Thruster Block
 
 		// CONTROL

--- a/GameData/002_CommunityPartsTitles/Localization/CPT_SpaceY_patch.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT_SpaceY_patch.cfg
@@ -66,14 +66,14 @@
 @PART[syx-engine-750-R9]:NEEDS[SpaceYExpanded] { @title = SpaceY R9 "Omega-Ratite" Engine Cluster     }  // SpaceY BFR9 "Omega-Ratite" Engine Cluster
 
 
-@PART[syl-rcs2]:NEEDS[SpaceYLifters]          { @title = RY-14x1 Linear RCS Port                   }  // SpaceY RCS-1x14 Linear RCS Port
-@PART[syl-rcs1]:NEEDS[SpaceYLifters]          { @title = RY-7x5 Thruster Block                     }  // SpaceY RCS-5x7 Thruster Block
-@PART[syl-oms1]:NEEDS[SpaceYLifters]          { @title = RY-O "Dibamus" RCS/OMS Thrust Block       }  // SpaceY "Dibamus" RCS/OMS Thrust Block
-@PART[syl-oms2]:NEEDS[SpaceYLifters]          { @title = RY-O "Super Dibamus" RCS/OMS Thrust Block }  // SpaceY "Super Dibamus" RCS/OMS Thrust Block
+@PART[syl-rcs-2]:NEEDS[SpaceYLifters]          { @title = RVa-141 Heavy Linear RCS Port (SpaceY)               }  // SpaceY RCS-1x14 Linear RCS Port
+@PART[syl-rcs-1]:NEEDS[SpaceYLifters]          { @title = RV-705 RSC Thruster Block (SpaceY)                   }  // SpaceY RCS-5x7 Thruster Block
+@PART[syl-oms-1]:NEEDS[SpaceYLifters]          { @title = RV-405 "Dibamus" RCS/OMS Thrust Block (SpaceY)       }  // SpaceY "Dibamus" RCS/OMS Thrust Block
+@PART[syl-oms-2]:NEEDS[SpaceYLifters]          { @title = RV-995 "Super Dibamus" RCS/OMS Thrust Block (SpaceY) }  // SpaceY "Super Dibamus" RCS/OMS Thrust Block
 
-@PART[syl-sasR3m]:NEEDS[SpaceYLifters]        { @title = WR-37X External Reaction Wheels            }  // SY-RWR3 3.75m External Reaction Wheels
-@PART[syl-sasR5m]:NEEDS[SpaceYLifters]        { @title = WR-50X External Reaction Wheels            }  // SY-RWR5 5m External Reaction Wheels
-// @PART[SYvernier1]:NEEDS[SpaceYExpanded]     { @title = Vernuer Thruster                          }  // SpaceY V1 Vernier Thruster
+@PART[syl-sasR3m]:NEEDS[SpaceYLifters]        { @title = WR-37X External Reaction Wheels (SpaceY)            }  // SY-RWR3 3.75m External Reaction Wheels
+@PART[syl-sasR5m]:NEEDS[SpaceYLifters]        { @title = WR-50X External Reaction Wheels (SpaceY)            }  // SY-RWR5 5m External Reaction Wheels
+@PART[syx-vernier1]:NEEDS[SpaceYExpanded]     { @title = RLa-991 Vernuer Thruster (SpaceY)                   }  // SpaceY V1 Vernier Thruster
 
 
 @PART[syl-SRBconeSize1]:NEEDS[SpaceYLifters]        { @title = AN-12 Sepratron Nose Cone (SpaceY)            }  // SpaceY SNC1 Sepratron Nose Cone (1.25m)

--- a/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
+++ b/GameData/002_CommunityPartsTitles/Localization/CPT__stock.cfg
@@ -196,18 +196,18 @@ Localization
 
 		// CONTROL
 
-		#autoLOC_8003429 = RV-01X "Place-Anywhere 1" Linear RCS Port    // Place Anywhere 1 Linear RCS Port 
-		#autoLOC_500894  = RV-105 "Place-Anywhere 7" Linear RCS Port    // Place-Anywhere 7 Linear RCS Port
+		#autoLOC_8003429 = RV-021 "Place-Anywhere 1" Linear RCS Port  // Place Anywhere 1 Linear RCS Port 
+		#autoLOC_500894  = RV-201 "Place-Anywhere 7" Linear RCS Port  // Place-Anywhere 7 Linear RCS Port
 
-		#autoLOC_8003432 = RV-01X RCS Thruster Block                    // RV-1X Variable Thruster Block
-		#autoLOC_500939  = RV-105 RCS Thruster Block                    // RV-105 RCS Thruster Block
+		#autoLOC_8003432 = RV-015 RCS Thruster Block                  // RV-1X Variable Thruster Block
+		#autoLOC_500939  = RV-105 RCS Thruster Block                  // RV-105 RCS Thruster Block
 
-		#autoLOC_500298 = WR-12 Advanced Inline Stabilizer              // Advanced Inline Stabilizer
-		#autoLOC_500286 = WR-25 Advanced Reaction Wheel Module (Large)  // Advanced Reaction Wheel Module, Large
-		#autoLOC_500301 = WR-06 Inline Reaction Wheel (Small)           // Small Inline Reaction Wheel
+		#autoLOC_500298 = WR-12 Advanced Inline Stabilizer               // Advanced Inline Stabilizer
+		#autoLOC_500286 = WR-25 Advanced Reaction Wheel Module (Large)   // Advanced Reaction Wheel Module, Large
+		#autoLOC_500301 = WR-06 Inline Reaction Wheel (Small)            // Small Inline Reaction Wheel
 
-		// #autoLOC_500148 = CH-J3 Fly-By-Wire Avionics Hub             // CH-J3 Fly-By-Wire Avionics Hub
-		// #autoLOC_500493 = Vernor Engine                              // Vernor Engine              - Generic (not strictly a vernier engine)
+		// #autoLOC_500148 = CH-J3 Fly-By-Wire Avionics Hub              // CH-J3 Fly-By-Wire Avionics Hub
+		#autoLOC_500493 = RLa-121 Vernor Engine                         // Vernor Engine              - Generic (not strictly a vernier engine)
 
 		// STRUCTURAL
 

--- a/Naming-Spec.md
+++ b/Naming-Spec.md
@@ -126,8 +126,10 @@ Tanks are named "*prefix*-*diameter*-*volume* 'nice' name".
 - *Nc* -- Radial-mounted Parachutes
 - *Nk* -- Nosecone or Inline-mounted Parachutes; suffix with *D* for Drogue parachutes
 - *OX* -- Solar Panels, requiring deployment (that can't be retracted) (c.f. *KX* and *SP*)
-- (WIP) *RL* -- RSC blocks (or engines) running on Liquid Fuel + Oxidizer. Numbers as per *RV*. (c.f. *RV*) 
-- (WIP) *RV* -- RCS blocks, Monopropellant Fuels. First value is thrust x10, followed by "x" and the (maximum) number of ports. Use a suffix of "A" for angled thrusters, and a suffix of "B" (for "booster") for higher than normal Isp (100s at Sea Level, 240s in Vacuum). (c.f. *RL*)
+- *RL* -- RCS blocks (or engines) running on Liquid Fuel + Oxidizer. Numbers as per *RV*. (c.f. *RV*)
+- *RLa* -- RCS blocks with thruster power greater than 1. For these, the first value is the thrust (not multiplied). (c.f. *RVa* and *RL*)
+- *RV* -- RCS blocks, Monopropellant Fuels. First value is thrust x10, followed the (maximum) number of ports. Use a suffix of "A" for angled thrusters, and a suffix of "H" (for "High Performance") for higher than normal Isp (100s at Sea Level, 240s in Vacuum). (c.f. *RL* and *RVa*)
+- *RVa* -- RCS blocks with thruster power greater than 1. For these, the first value is the thrust (not multiplied). (c.f. *RV*)
 - *SEQ* -- Storage Containers. First value is diameter, and second combined value is slots/volume.
 - *SM* -- Service Module
 - *SP* -- Solar Panels, that can be deployed and retracted (c.f. *KX* and *OX*)


### PR DESCRIPTION
Further to your comment on #20, this is my attempt to make sense of RCS blocks.

I don't know if there was a previous naming system that I totally ignored here. I somewhat wish that I could figure out is how to drop the leading zero, but there are certain blocks that have thrust power of 10 or 12 (or in one case, 100!). It's also slightly weird to multiple the thruster power by 10 (do we do that for any other series?), but not doing so would require lots of decimals.

As always, comments / suggestions / recommendations / concerns / alternatives are welcome.